### PR TITLE
Issue 3 retrying addressprovider

### DIFF
--- a/functional-tests/src/test/java/custom/CustomJarInClasspathIT.java
+++ b/functional-tests/src/test/java/custom/CustomJarInClasspathIT.java
@@ -46,7 +46,6 @@ import static org.hamcrest.CoreMatchers.is;
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CustomParameterizedRunner.Factory.class)
-@Ignore
 public class CustomJarInClasspathIT extends BaseHelmChartTest
     {
     // ----- test lifecycle --------------------------------------------------

--- a/functional-tests/src/test/java/helm/BaseHelmChartTest.java
+++ b/functional-tests/src/test/java/helm/BaseHelmChartTest.java
@@ -1999,8 +1999,23 @@ public abstract class BaseHelmChartTest
      */
     protected static Application portForwardCoherencePod(K8sCluster k8sCluster, String sNamespace, String sRelease, int nPort) throws Exception
         {
+        final int MAX_RETRY     = 3;
+        Exception lastException = null;
+
         String sSelector = getCoherencePodSelector(sRelease);
-        return portForward(k8sCluster, sNamespace, sSelector, nPort);
+        for (int i=0; i < MAX_RETRY; i++)
+            {
+            try
+                {
+                return portForward(k8sCluster, sNamespace, sSelector, nPort);
+                }
+            catch (Exception e)
+                {
+                lastException = e;
+                }
+            }
+
+        throw lastException;
         }
 
     /**

--- a/functional-tests/src/test/java/helm/BasicConnectivityIT.java
+++ b/functional-tests/src/test/java/helm/BasicConnectivityIT.java
@@ -62,7 +62,6 @@ public class BasicConnectivityIT
         }
 
     @Test
-    @Ignore
     public void shouldConnectToMetricsPort() throws Exception
         {
         assumeThat(versionCheck("12.2.1.4.0"), is(true));
@@ -82,7 +81,6 @@ public class BasicConnectivityIT
         }
 
     @Test
-    @Ignore
     public void shouldConnectToExtendPort() throws Exception
         {
         m_sRelease = installCoherence(m_k8sCluster, m_sNamespace, DEFAULT_VALUES_YAML);
@@ -101,7 +99,6 @@ public class BasicConnectivityIT
         }
 
     @Test
-    @Ignore
     public void shouldConnectToJmxPort() throws Exception
         {
         m_sRelease = installCoherence(m_k8sCluster,

--- a/functional-tests/src/test/java/helm/ClusteringIT.java
+++ b/functional-tests/src/test/java/helm/ClusteringIT.java
@@ -32,6 +32,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
@@ -75,6 +77,11 @@ public class ClusteringIT
         m_listRelease.stream()
                 .filter(Objects::nonNull)
                 .forEach(sRelease -> deleteCoherence(s_k8sCluster, getK8sNamespace(), sRelease, false));
+
+        if (m_headlessService != null)
+            {
+            s_k8sCluster.kubectlAndWait(Arguments.of("-n", getK8sNamespace(), "delete", "svc", m_headlessService));
+            }
         }
 
     // ----- test methods ---------------------------------------------------
@@ -154,7 +161,79 @@ public class ClusteringIT
         listPodsInService = getPodsInService(sNamespace, sWkaService);
 
         assertThat(listPodsInService, is(listPod));
+        s_k8sCluster.kubectlAndWait(Arguments.of("-n", sNamespace, "delete", "svc", sWkaService));
         }
+
+    // Integration test for RetryingWkaAddressProvider that waits for wka dns entry to come up
+    @Test
+    public void shouldFormClusterUsingDeferredHeadlessService() throws Exception
+        {
+        String   sNamespace      = getK8sNamespace();
+        String   sClusterName    = "bar";
+        String   sWkaService     = "bar-wka-service";
+        String   sValClusterSize = "clusterSize=2";
+        String   sValClusterName = "cluster=" + sClusterName;
+        String   sWka            = "store.wka=" + sWkaService;
+        String   sValEnableJmx   = "store.jmx.enabled=true";
+        String[] asSetArgsOne    = {sValClusterName, sValClusterSize, sWka, sValEnableJmx};
+        String   sValuesFile     = "values/helm-values-coh.yaml";
+
+        // rather than start headless service referenced in wka first,
+        // ensure that cluster can form despite delay in headless service creation.
+        // simulates behavior when coherence headless service does not start immediately waiting for volume claims.
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        Runnable task = new Runnable()
+            {
+            public void run()
+                {
+                try
+                    {
+                    createHeadlessService(sNamespace, sWkaService, sClusterName);
+                    }
+                catch (Throwable t)
+                    {
+                    fail("delayed start of wka service bar-wka-service failed with exception " + t);
+                    t.printStackTrace();
+                    }
+                }
+            };
+
+        scheduler.schedule(task, 45, TimeUnit.SECONDS);
+        scheduler.shutdown();
+
+        String sReleaseOne = installCoherence(s_k8sCluster, sNamespace, sValuesFile, asSetArgsOne);
+
+        m_listRelease.add(sReleaseOne);
+
+        assertCoherence(s_k8sCluster, sNamespace, sReleaseOne);
+        assertCoherenceJMX(s_k8sCluster, sNamespace, sReleaseOne);
+
+        Eventually.assertThat(invoking(this).getClusterSizeViaJMX(s_k8sCluster, sNamespace, sReleaseOne),
+            greaterThanOrEqualTo(3), RetryFrequency.every(10, TimeUnit.SECONDS), Timeout.after(60, TimeUnit.SECONDS));
+
+        List<String> listPod           = getPods(s_k8sCluster, sNamespace, getCoherencePodSelector(sReleaseOne));
+        List<String> listPodsInService = getPodsInService(sNamespace, sWkaService);
+
+        assertThat(listPodsInService, is(listPod));
+
+        String[] asSetArgsTwo = {sValClusterName, sValClusterSize, sWka};
+        String sReleaseTwo = installCoherence(s_k8sCluster, sNamespace, sValuesFile, asSetArgsTwo);
+
+        m_listRelease.add(sReleaseTwo);
+
+        assertCoherence(s_k8sCluster, sNamespace, sReleaseTwo);
+
+        Eventually.assertThat(invoking(this).getClusterSizeViaJMX(s_k8sCluster, sNamespace, sReleaseOne),
+            greaterThanOrEqualTo(5), RetryFrequency.every(10, TimeUnit.SECONDS), Timeout.after(60, TimeUnit.SECONDS));
+
+        listPod.addAll(getPods(s_k8sCluster, sNamespace, getCoherencePodSelector(sReleaseTwo)));
+        Collections.sort(listPod);
+
+        listPodsInService = getPodsInService(sNamespace, sWkaService);
+
+        assertThat(listPodsInService, is(listPod));
+        }
+
 
     // ----- helper methods -------------------------------------------------
 
@@ -225,6 +304,8 @@ public class ClusteringIT
         int nExitCode = s_k8sCluster.kubectlAndWait(Arguments.of("-n", sNamespace, "create", "-f", file.getCanonicalPath()));
 
         assertThat("Creation of headless service failed", nExitCode, is(0));
+
+        m_headlessService = sServiceName;
         }
 
     private Application portForwardManagement(String sNamespace, String sRelease) throws Exception
@@ -257,6 +338,11 @@ public class ClusteringIT
      * The name of the deployed Coherence Helm release.
      */
     private final List<String> m_listRelease = new ArrayList<>();
+
+    /**
+     * The name of the headless service used by current test.
+     */
+    private String             m_headlessService;
 
     /**
      * The mapper to parse json.

--- a/functional-tests/src/test/java/helm/EFKHelmChartIT.java
+++ b/functional-tests/src/test/java/helm/EFKHelmChartIT.java
@@ -162,7 +162,6 @@ public class EFKHelmChartIT
      * @throws Exception
      */
     @Test
-    @Ignore
     public void testCoherenceRoleClusterUid() throws Exception
         {
         String[] asCohNamespaces = getTargetNamespaces();

--- a/functional-tests/src/test/java/helm/LogHelmChartIT.java
+++ b/functional-tests/src/test/java/helm/LogHelmChartIT.java
@@ -30,7 +30,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author sc
  */
-@Ignore
 public class LogHelmChartIT
         extends BaseHelmChartTest {
 

--- a/functional-tests/src/test/java/helm/ManagementHttpsIT.java
+++ b/functional-tests/src/test/java/helm/ManagementHttpsIT.java
@@ -22,7 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author jk  2019.02.21
  */
-@Ignore
 public class ManagementHttpsIT
         extends BaseHttpsTest
     {

--- a/functional-tests/src/test/java/helm/MetricsHttpsIT.java
+++ b/functional-tests/src/test/java/helm/MetricsHttpsIT.java
@@ -22,7 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author jk  2019.02.21
  */
-@Ignore
 public class MetricsHttpsIT
         extends BaseHttpsTest
     {

--- a/functional-tests/src/test/java/helm/PersistenceSnapshotHelmChartIT.java
+++ b/functional-tests/src/test/java/helm/PersistenceSnapshotHelmChartIT.java
@@ -179,7 +179,6 @@ public class PersistenceSnapshotHelmChartIT
      * @throws Exception if the test fails
      */
     @Test
-    @Ignore
     public void testSnapshotWithoutPersistenceWithVol() throws Exception
         {
         testPersistence("values/helm-values-coh-snapshot-vol.yaml", false, false);

--- a/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
+++ b/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertTrue;
  * @author jf
  * @author sc
  */
-@Ignore
 public class PrometheusOperatorHelmSubChartIT
     extends BaseHelmChartTest
     {

--- a/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
+++ b/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
@@ -107,6 +107,7 @@ public class PrometheusOperatorHelmSubChartIT
      * Test with user supplied prometheus_io annotations with coherence-service-monitor disabled.
      * @throws Exception
      */
+    @Ignore
     @Test
     public void testPrometheusOperatorSubchartWithUserSuppliedAdditionalScrapeConfig()
         throws Exception
@@ -175,8 +176,8 @@ public class PrometheusOperatorHelmSubChartIT
             System.err.println("validating cluster size of " + CLUSTER_NAME + " in namespace " + asCohNamespaces[i] + " for coherence release " + m_asReleases[i]);
             Eventually.assertThat(invoking(this).getPrometheusMetricAsLong("coherence_cluster_size", CLUSTER_NAME, asCohNamespaces[i], sOpNamespace),
                 greaterThanOrEqualTo(EXPECTED_CLUSTER_SIZE),
-                RetryFrequency.every(10, TimeUnit.SECONDS),
-                Timeout.after(4, TimeUnit.MINUTES));
+                RetryFrequency.every(15, TimeUnit.SECONDS),
+                Timeout.after(2, TimeUnit.MINUTES));
             }
         }
 

--- a/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
+++ b/functional-tests/src/test/java/helm/PrometheusOperatorHelmSubChartIT.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertTrue;
  * @author jf
  * @author sc
  */
+@Ignore
 public class PrometheusOperatorHelmSubChartIT
     extends BaseHelmChartTest
     {
@@ -107,7 +108,6 @@ public class PrometheusOperatorHelmSubChartIT
      * Test with user supplied prometheus_io annotations with coherence-service-monitor disabled.
      * @throws Exception
      */
-    @Ignore
     @Test
     public void testPrometheusOperatorSubchartWithUserSuppliedAdditionalScrapeConfig()
         throws Exception

--- a/functional-tests/src/test/java/helm/VolumesIT.java
+++ b/functional-tests/src/test/java/helm/VolumesIT.java
@@ -30,7 +30,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author jk  2019.02.12
  */
-@Ignore
 public class VolumesIT
         extends BaseHelmChartTest
     {

--- a/operator/src/main/helm/coherence/scripts/k8s-coherence-nossl-override.xml
+++ b/operator/src/main/helm/coherence/scripts/k8s-coherence-nossl-override.xml
@@ -21,24 +21,5 @@
         </address-provider>
       </well-known-addresses>
     </unicast-listener>
-    <socket-providers>
-      <socket-provider id="ManagementSSLProvider">
-        <ssl>
-          <identity-manager>
-            <key-store>
-              <url system-property="test.keystore"/>
-              <password>password</password>
-            </key-store>
-            <password>password</password>
-          </identity-manager>
-          <trust-manager>
-            <key-store>
-              <url system-property="test.truststore"/>
-              <password>secret</password>
-            </key-store>
-          </trust-manager>
-        </ssl>
-      </socket-provider>
-    </socket-providers>
   </cluster-config>
 </coherence>

--- a/operator/src/main/helm/coherence/scripts/k8s-coherence-override.xml
+++ b/operator/src/main/helm/coherence/scripts/k8s-coherence-override.xml
@@ -10,6 +10,15 @@
             xml-override="{coherence.k8s.override /tangosol-coherence-override.xml}">
 
   <cluster-config>
+    <unicast-listener>
+      <well-known-addresses>
+        <address-provider>
+          <class-factory-name>com.oracle.coherence.k8s.RetryingWkaAddressProvider
+          </class-factory-name>
+          <method-name>create</method-name>
+        </address-provider>
+      </well-known-addresses>
+    </unicast-listener>
     <socket-providers>
       <socket-provider id="ManagementSSLProvider">
         <ssl>

--- a/operator/src/main/helm/coherence/scripts/startCoherence.sh
+++ b/operator/src/main/helm/coherence/scripts/startCoherence.sh
@@ -359,9 +359,16 @@ configure_pre_12_2_1_4()
     {
     echo "Adding configuration for pre-12.2.1.4.0 version"
 
+    #   This is pre Coherence 12.2.1.4.0
+    #   copy our AddressProvider overrides file onto the classpath
+    cp /scripts/k8s-coherence-nossl-override.xml ${COHERENCE_HOME}/conf/k8s-coherence-nossl-override.xml
+
+    #   use our AddressProvider overrides file
+    PROPS="${PROPS} -Dcoherence.override=k8s-coherence-nossl-override.xml"
+
     if [[ -n "${COH_OVERRIDE_CONFIG}" ]]
     then
-        PROPS="${PROPS} -Dcoherence.override=${COH_OVERRIDE_CONFIG}"
+        PROPS="${PROPS} -Dcoherence.k8s.override=${COH_OVERRIDE_CONFIG}"
     fi
     }
 
@@ -374,10 +381,10 @@ configure_12_2_1_4()
     echo "Adding configuration for 12.2.1.4.0 and above"
 
 #   This is Coherence 12.2.1.4.0 or above so we support SSL management and metrics
-#   copy our SSL overrides file onto the classpath
+#   copy our AddressProvider and SSL overrides file onto the classpath
     cp /scripts/k8s-coherence-override.xml ${COHERENCE_HOME}/conf/k8s-coherence-override.xml
 
-#   use our SSL overrides file
+#   use our AP and SSL overrides file
     PROPS="${PROPS} -Dcoherence.override=k8s-coherence-override.xml"
 
     if [[ -n "${COH_OVERRIDE_CONFIG}" ]]

--- a/utils/src/main/java/com/oracle/coherence/k8s/RetryingWkaAddressProvider.java
+++ b/utils/src/main/java/com/oracle/coherence/k8s/RetryingWkaAddressProvider.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.k8s;
+
+import com.oracle.common.util.Duration;
+import com.oracle.common.util.Duration.Magnitude;
+import com.tangosol.net.AddressProvider;
+import com.tangosol.net.ConfigurableAddressProvider;
+import com.tangosol.util.Base;
+import com.tangosol.util.WrapperException;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An AddressProvider that eventually resolves at least one dns host name in provided WKA list, {@link #PROP_WKA_OVERRIDE}.
+ * Throws an exception if unable to resolve at least one host name within {@link #f_WkaDNSResolutionTimeout_ms}.
+ */
+public class RetryingWkaAddressProvider
+    extends ConfigurableAddressProvider
+    {
+    // ----- Constructors ---------------------------------------------------
+
+    /**
+     * Construct a {@link RetryingWkaAddressProvider}
+     *
+     * @param addressHolders  the {@link AddressHolder}s
+     * @param fSafe           true if the provider skips unresolved addresses
+     * @param timeout_ms      maximum time in milliseconds to attempt to resolve {@link AddressHolder}s
+     * @param frequency_ms    frequency in milliseconds to attempt to retry {@link AddressHolder} dns resolution
+     */
+    public RetryingWkaAddressProvider(Iterable<AddressHolder> addressHolders, boolean fSafe, long frequency_ms, long timeout_ms)
+        {
+        super(addressHolders, fSafe);
+
+        f_WkaDNSReresolveFrequency_ms = frequency_ms;
+        f_WkaDNSResolutionTimeout_ms  = timeout_ms;
+        }
+
+    /**
+     * Create an {@link AddressProvider} using System properties for the WKA override.
+     * <p>
+     * The {@link #PROP_WKA_OVERRIDE} property is used to obtain a WKA override value, if
+     * this value is set a {@link ConfigurableAddressProvider} will be returned using the
+     * addresses from the {@link #PROP_WKA_OVERRIDE} property.
+     * <p>
+     * If {@link #PROP_WKA_OVERRIDE} is not set an empty
+     * {@link ConfigurableAddressProvider} will be returned.
+     *
+     *
+     * @return an {@link AddressProvider}.
+     */
+    public static AddressProvider create()
+        throws UnknownHostException
+        {
+        return create(System.getProperty(PROP_WKA_OVERRIDE));
+        }
+
+    /**
+     * Create an {@link AddressProvider} using a comma delimited list of addresses and configured with
+     * system properties {@link #PROP_WKA_RERESOLVE_FREQUENCY} and {@link #PROP_WKA_TIMEOUT}.
+     * <p>
+     * The sWkaOverride parameter is used to obtain a WKA override value, if
+     * this parameter is not null a {@link ConfigurableAddressProvider} will be
+     * returned using the addresses from the sWkaOverride parameter.
+     * <p>
+     * If the sWkaOverride parameter is null then an empty
+     * {@link ConfigurableAddressProvider} will be returned.
+     *
+     * @param sWkaOverride  the comma delimited WKA address list
+     *
+     * @return an {@link AddressProvider}.
+     *
+     * @throws UnknownHostException if unable to dns resolve at least one address in wka list
+     */
+    public static AddressProvider create(String sWkaOverride)
+        throws UnknownHostException
+        {
+        return create(sWkaOverride, new Duration(System.getProperty(PROP_WKA_RERESOLVE_FREQUENCY, "2s")).as(Duration.Magnitude.MILLI),
+            new Duration(System.getProperty(PROP_WKA_TIMEOUT, "6m")).as(Duration.Magnitude.MILLI));
+        }
+
+    /**
+     * Create an {@link AddressProvider} configured by provided parameters.
+     *
+     * @param frequency_ms frequency in milliseconds to retry dns resolution of wka address list
+     * @param timeout_ms   timeout in milliseconds to abort retry of dns resolution of wka address list and throw an exception
+     *
+     * @return {@link AddressProvider}
+     *
+     * @throws UnknownHostException if unable to dns resolve at least one address in wka list
+     */
+    public static AddressProvider create(String sWkaOverride, long frequency_ms, long timeout_ms)
+        throws UnknownHostException
+        {
+        if (sWkaOverride == null)
+            {
+            return new ConfigurableAddressProvider(Collections.emptyList(), true);
+            }
+        else
+            {
+            String[] asAddresses = sWkaOverride.split(",");
+
+            List<AddressHolder> list = Arrays.stream(asAddresses)
+                .map(sAddr -> new ConfigurableAddressProvider.AddressHolder(sAddr, 0))
+                .collect(Collectors.toList());
+
+            RetryingWkaAddressProvider provider = new RetryingWkaAddressProvider(list, true, frequency_ms, timeout_ms);
+            return provider.eventuallyResolve();
+            }
+        }
+
+    /**
+     * Create an {@link AddressProvider} using System property for the WKA override
+     * <p>
+     * The {@link #PROP_WKA_OVERRIDE} property is used to obtain a WKA override value, if
+     * this value is set a {@link ConfigurableAddressProvider} will be returned using the
+     * addresses from the {@link #PROP_WKA_OVERRIDE} property.
+     * <p>
+     * If {@link #PROP_WKA_OVERRIDE} is not set an empty
+     * {@link ConfigurableAddressProvider} will be returned.
+     *
+     * @param sDurationFrequency retry wka resolve frequency as duration string, see format documented in {@see Duration(String)}
+     * @param sDurationTimeout   timeout wka resolve as duration string, examples are "120s", "2m" and "2000ms", all durations of 2 minutes.
+     *
+     * @return {@link AddressProvider}
+     *
+     * @throws UnknownHostException if unable to dns resolve at least one address in wka list
+     */
+    public static AddressProvider create(String sDurationFrequency, String sDurationTimeout)
+        throws UnknownHostException
+        {
+        return create(System.getProperty(PROP_WKA_OVERRIDE),
+            new Duration(sDurationFrequency).as(Magnitude.MILLI), new Duration(sDurationTimeout).as(Magnitude.MILLI));
+        }
+
+    // ----- helpers --------------------------------------------------------
+
+    /**
+     * Attempt resolution of each dns reference in wka until at least on dns reference resolves
+     * or throw an {@link IOException} after {@link #f_WkaDNSResolutionTimeout_ms}.
+     *
+     * @return this {@link RetryingWkaAddressProvider} instance
+     *
+     * @throws WrapperException if no dns references resolve within {@link #f_WkaDNSResolutionTimeout_ms}.
+     */
+    public AddressProvider eventuallyResolve()
+        throws UnknownHostException
+        {
+        long ldtStart = Base.getLastSafeTimeMillis();
+
+        m_nLastReresolveCount = 0;
+        while ((Base.getLastSafeTimeMillis() - ldtStart) < f_WkaDNSResolutionTimeout_ms)
+            {
+            m_nLastReresolveCount++;
+            if (getNextAddress() == null)
+                {
+                Base.sleep(f_WkaDNSReresolveFrequency_ms);
+                reset();
+                }
+            else
+                {
+                reset();
+                return this;
+                }
+            }
+
+        throw new UnknownHostException(RetryingWkaAddressProvider.class.getName() +
+            " failed to resolve configured WKA address(es) " + System.getProperty(PROP_WKA_OVERRIDE) +
+            " within " + f_WkaDNSResolutionTimeout_ms + " milliseconds.");
+        }
+
+    /**
+     * The name of the System property to use to return a fixed WKA list.
+     */
+    public static final String PROP_WKA_OVERRIDE = "coherence.wka";
+
+    /**
+     * The name of the System property to configure maximum time to attempt to resolve wka addresses.
+     * Provides default value for {link #f_WkaDNSResolutionTimeout_ms}. Set this system property
+     * to the format of the string parameter described in {@link Duration(String)}.  Example settings
+     * are "10s", "20m", "60000ms" for 10 seconds, 20 minutes and 60,000 milliseconds respectively.
+     */
+    public static final String PROP_WKA_TIMEOUT = RetryingWkaAddressProvider.class.getName() + ".dnsResolutionTimeout";
+
+    /**
+     * System property for configuring the frequency to attempt dns resolution of wka addresses.
+     * Provides default value for {link #f_WkaDNSReresolveFrequency_ms}. Set this system property
+     * to the format of the string parameter described in {@link Duration(String)}.  Example settings
+     * are "10s", "20m", "60000ms" for 10 seconds, 20 minutes and 60,000 milliseconds respectively.
+     */
+    public static final String PROP_WKA_RERESOLVE_FREQUENCY = RetryingWkaAddressProvider.class.getName() + ".dnsResolutionFrequency";
+
+    /**
+     * WKA DNS Resolution frequency.
+     */
+    public final long f_WkaDNSReresolveFrequency_ms;
+
+    /**
+     * The timeout value for wks address resolution.
+     */
+    public final long f_WkaDNSResolutionTimeout_ms;
+
+    /**
+     * Added for testing verification.
+     * Count of how many times a DNS resolve of entire WKA address list has been performed.
+     */
+    int m_nLastReresolveCount;
+    }

--- a/utils/src/test/java/com/oracle/coherence/k8s/RetryingWkaAddressProviderTest.java
+++ b/utils/src/test/java/com/oracle/coherence/k8s/RetryingWkaAddressProviderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.k8s;
+
+import com.oracle.common.util.Duration;
+
+import com.tangosol.net.ConfigurableAddressProvider.AddressHolder;
+import com.tangosol.util.Base;
+import com.tangosol.util.WrapperException;
+
+import org.junit.Test;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static com.oracle.coherence.k8s.RetryingWkaAddressProvider.*;
+import static com.oracle.common.util.Duration.Magnitude.MILLI;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class RetryingWkaAddressProviderTest
+    {
+    @Test(expected = UnknownHostException.class)
+    public void testShouldTimeoutOnNonExistentDnsReference()
+        throws UnknownHostException
+        {
+        final long FREQUENCY_MS = 500;
+        final long TIMEOUT_MS   = 5000;
+
+        long ldtStart = Base.getLastSafeTimeMillis();
+        Iterable<AddressHolder> holders = new Iterable<AddressHolder>()
+            {
+            @Override
+            public Iterator<AddressHolder> iterator()
+                {
+                return Arrays.asList(new AddressHolder("NonExiStentHoStName12345678", 0)).iterator();
+                }
+
+            };
+        RetryingWkaAddressProvider provider = new RetryingWkaAddressProvider(holders, true, FREQUENCY_MS, TIMEOUT_MS);
+        try
+            {
+            provider.eventuallyResolve();
+            fail("should throw exception");
+            }
+        finally
+            {
+            long ldtTimeoutDuration = Base.getLastSafeTimeMillis() - ldtStart;
+
+            assertThat("validate reresolve happened over specified minimum timeout",
+                ldtTimeoutDuration, greaterThanOrEqualTo(TIMEOUT_MS));
+            assertThat("validate lower bound of reresolve count" ,
+                provider.m_nLastReresolveCount, greaterThanOrEqualTo(3));
+            assertThat("validate upper bound of reresolve count" ,
+                provider.m_nLastReresolveCount, lessThanOrEqualTo((int)(TIMEOUT_MS / FREQUENCY_MS)));
+            }
+        }
+
+    @Test
+    public void testShouldRevolveImmediately()
+        throws UnknownHostException
+        {
+        final long FREQUENCY_MS = 3022;
+        final long TIMEOUT_MS   = 13456;
+
+        RetryingWkaAddressProvider provider =
+            (RetryingWkaAddressProvider) create("127.0.0.1", FREQUENCY_MS, TIMEOUT_MS);
+
+        assertNotNull("confirm wka resolved", provider.getNextAddress());
+        assertThat("validate configured frequency of reresolve", provider.f_WkaDNSReresolveFrequency_ms, is(FREQUENCY_MS));
+        assertThat("validate configured frequency of reresolve", provider.f_WkaDNSResolutionTimeout_ms, is(TIMEOUT_MS));
+        }
+
+    @Test
+    public void shouldConfigureBySystemProperties()
+        throws UnknownHostException
+        {
+        String sTimeout   = "4m";
+        String sFrequency = "22s";
+
+        System.setProperty(PROP_WKA_OVERRIDE, "127.0.0.1");
+        System.setProperty(PROP_WKA_TIMEOUT, sTimeout);
+        System.setProperty(PROP_WKA_RERESOLVE_FREQUENCY, sFrequency);
+
+        try
+            {
+            RetryingWkaAddressProvider provider = (RetryingWkaAddressProvider) create();
+            assertNotNull("confirm wka resolved", provider.getNextAddress());
+            assertThat("validate configured frequency of dns resolve",
+                provider.f_WkaDNSReresolveFrequency_ms, is(new Duration(sFrequency).as(MILLI)));
+            assertThat("validate configured max time to attempt to resolve wka dns addresses",
+                provider.f_WkaDNSResolutionTimeout_ms, is(new Duration(sTimeout).as(MILLI)));
+            }
+        finally
+            {
+            System.clearProperty(PROP_WKA_OVERRIDE);
+            System.clearProperty(PROP_WKA_TIMEOUT);
+            System.clearProperty(PROP_WKA_RERESOLVE_FREQUENCY);
+            }
+        }
+
+    @Test
+    public void testCreateWithDurationParameters()
+        throws UnknownHostException
+        {
+        final String FREQUENCY_DURATION = "2s";
+        final String TIMEOUT_DURATION = "6s";
+
+        System.setProperty(PROP_WKA_OVERRIDE, "127.0.0.1");
+
+        try
+            {
+            RetryingWkaAddressProvider provider =
+                (RetryingWkaAddressProvider) create(FREQUENCY_DURATION, TIMEOUT_DURATION);
+
+            assertNotNull("confirm wka resolved", provider.getNextAddress());
+            assertThat("validate configured frequency of reresolve",
+                provider.f_WkaDNSReresolveFrequency_ms, is(new Duration(FREQUENCY_DURATION).as(MILLI)));
+            assertThat("validate configured frequency of reresolve",
+                provider.f_WkaDNSResolutionTimeout_ms, is(new Duration(TIMEOUT_DURATION).as(MILLI)));
+            }
+        finally
+            {
+            System.clearProperty(PROP_WKA_OVERRIDE);
+            }
+        }
+    }


### PR DESCRIPTION
Added RetryingWkaAddressProvider, unit test to utils module.
Added integration test to functional-tests ClusterIT deferring start of coherence-headless-server that wka was set to.  Also removed workaround for killing jmx server when it started in multicast. 

Hardened portforwarding (retrying 3 times) so could remove @Ignore added in master.
