### PR TITLE
Retry logic for failed kc port forward and exec

### DIFF
--- a/functional-tests/src/test/java/custom/MetricsUsingCustomJarInClasspathIT.java
+++ b/functional-tests/src/test/java/custom/MetricsUsingCustomJarInClasspathIT.java
@@ -178,7 +178,7 @@ public class MetricsUsingCustomJarInClasspathIT
      */
     Queue<String> getMetricsScrape(String sPod)
         {
-        return processHttpRequest(s_k8sCluster, sPod, "GET", "localhost", 9095, "/metrics", /*fConsole*/ false);
+        return processHttpRequest(s_k8sCluster, sPod, "GET", "localhost", 9095, "/metrics");
         }
 
     /**


### PR DESCRIPTION
Retry logic in functional test framework for failed kubectl port-forward and kubectl exec.

Retry them 3 times before failing.

Here is failure from BaseHelmChart.processHttpRequest 

[exec-i-http:err]    0: Error from server: error dialing backend: remote error: tls: record overflow
 