### PR TITLE
Update docker-hub-readme.md for cross linking to official Coherence page

### DIFF
--- a/docker-hub-readme.md
+++ b/docker-hub-readme.md
@@ -1,10 +1,10 @@
-# Docker Images for Oracle Coherence Kubernetes Operator
+# Docker Images for Oracle Coherence Operator
 
-Oracle enables organizations using Coherence to move their clusters
+Oracle enables organizations using [Coherence](https://www.oracle.com/technetwork/middleware/coherence/overview/index.html) to move their clusters
 into the cloud. By supporting de facto standards such as Docker and
 Kubernetes, Oracle facilitates running Coherence on cloud-neutral
 infrastructure. In particular, Oracle provides an open-source
-Coherence Kubernetes Operator, which implements features to assist
+Coherence Operator, which implements features to assist
 with deploying and managing Coherence clusters in a Kubernetes
 environment. You can:
 


### PR DESCRIPTION
Change the Docker Hub description :
1. Change the Coherence Kubernetes Operator to just Coherence Operator
2. In the first paragraph link Coherence to the official Coherence page https://www.oracle.com/technetwork/middleware/coherence/overview/index.html so that any new users can get more information about Coherence from there