### PR TITLE
126 validate docs gh pages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,158 @@
+pipeline {
+    agent none
+    environment {
+        HTTP_PROXY  = credentials('coherence-operator-http-proxy')
+        HTTPS_PROXY = credentials('coherence-operator-https-proxy')
+        NO_PROXY    = credentials('coherence-operator-no-proxy')
+    }
+    options {
+        lock('kubernetes-stage1')
+    }
+    stages {
+        stage('maven-build') {
+            agent {
+              label 'Kubernetes'
+            }
+            steps {
+                echo 'Maven Build'
+                sh '''
+                    if [ -z "$HTTP_PROXY" ]; then
+                        unset HTTP_PROXY
+                        unset HTTPS_PROXY
+                        unset NO_PROXY
+                    fi
+                    helm init --client-only --skip-refresh
+                '''
+                withMaven(jdk: 'Jdk11', maven: 'Maven3.6.0', mavenSettingsConfig: 'coherence-operator-maven-settings', tempBinDir: '') {
+                   sh '''
+		       cd docs/samples 
+		       # Specify temporary version until chart supplies correct one
+		       mvn clean install -Dcoherence.docker.version=12.2.1.3.1
+		   '''
+                }
+            }
+        }
+        stage('docker-build') {
+            agent {
+                label 'Kubernetes'
+            }
+            steps {
+                echo 'Docker Build'
+                sh '''
+		    docker swarm leave --force || true
+                    docker swarm init
+                    if [ -z "$HTTP_PROXY" ]; then
+                        unset HTTP_PROXY
+                        unset HTTPS_PROXY
+                        unset NO_PROXY
+                    fi
+                    helm init --client-only
+                '''
+                withMaven(jdk: 'Jdk11', maven: 'Maven3.6.0', mavenSettingsConfig: 'coherence-operator-maven-settings', tempBinDir: '') {
+                    sh '''
+                        cd docs/samples 
+		        mvn -Dcoherence.docker.version=12.2.1.3.1 -P docker,docker-v1,docker-v2 clean install
+		    '''
+                }
+            }
+        }
+        stage('docker-push') {
+            agent {
+                label 'Kubernetes'
+            }
+            steps {
+                echo 'Docker Push'
+                sh '''
+                    if [ -z "$HTTP_PROXY" ]; then
+                        unset HTTP_PROXY
+                        unset HTTPS_PROXY
+                        unset NO_PROXY
+                    fi
+                '''
+                withMaven(jdk: 'Jdk11', maven: 'Maven3.6.0', mavenSettingsConfig: 'coherence-operator-maven-settings', tempBinDir: '') {
+                    sh ''' 
+                        cd docs/samples 
+                        mvn install -P dockerPush
+                    '''
+                }
+            }
+        }
+        stage('kubernetes-samples-tests') {
+            agent {
+                label 'Kubernetes'
+            }
+            steps {
+                echo 'Kubernetes Tests'
+                withCredentials([
+                    string(credentialsId: 'coherence-operator-docker-pull-secret-email',    variable: 'PULL_SECRET_EMAIL'),
+                    string(credentialsId: 'coherence-operator-docker-pull-secret-password', variable: 'PULL_SECRET_PASSWORD'),
+                    string(credentialsId: 'coherence-operator-docker-pull-secret-username', variable: 'PULL_SECRET_USERNAME'),
+                    string(credentialsId: 'coherence-operator-docker-pull-secret-server',   variable: 'PULL_SECRET_SERVER')]) {
+                    sh '''
+                        if [ -z "$HTTP_PROXY" ]; then
+                            unset HTTP_PROXY
+                            unset HTTPS_PROXY
+                            unset NO_PROXY
+                        fi
+
+                        helm init --client-only
+                        export HELM_TILLER_LOGS=false
+			export NS=test-sample-${BUILD_NUMBER}
+                        helm tiller start-ci $NS
+                        export TILLER_NAMESPACE=$NS
+                        export HELM_HOST=:44134
+                        helm repo add coherence https://oracle.github.io/coherence-operator/charts
+		        helm repo update
+                        kubectl create namespace $NS || true
+                        kubectl create secret docker-registry coherence-k8s-operator-development-secret \
+                           --namespace $NS \
+                           --docker-server=$PULL_SECRET_SERVER \
+                           --docker-username=$PULL_SECRET_USERNAME \
+                           --docker-password="$PULL_SECRET_PASSWORD" \
+                           --docker-email=$PULL_SECRET_EMAIL || true
+                        kubectl create secret docker-registry sample-coherence-secret \
+                           --namespace $NS \
+                           --docker-server=$PULL_SECRET_SERVER \
+                           --docker-username=$PULL_SECRET_USERNAME \
+                           --docker-password="$PULL_SECRET_PASSWORD" \
+                           --docker-email=$PULL_SECRET_EMAIL || true
+                    '''
+                    withMaven(jdk: 'Jdk11', maven: 'Maven3.6.0', mavenSettingsConfig: 'coherence-operator-maven-settings', tempBinDir: '') {
+                        sh '''
+                            export HELM_BINARY=`which helm`
+                            export KUBECTL_BINARY=`which kubectl`
+                            export NS=test-sample-${BUILD_NUMBER}
+		            cd docs/samples 
+                            mvn -Dbedrock.helm=''$HELM_BINARY'' \
+                                -Dk8s.kubectl=''$KUBECTL_BINARY'' \
+                                -Dop.image.pull.policy=Always \
+                                -Dci.build=$BUILD_NUMBER \
+				-Dcoherence.docker.version=12.2.1.3.1 \
+                                -Dk8s.image.pull.secret=coherence-k8s-operator-development-secret \
+                                -Dk8s.create.namespace=false \
+				-Dk8s.chart.test.versions=0.9.4 \
+				-Dk8s.namespace=$NS \
+                                -P helm-test clean install
+                        '''
+                    }
+                }
+            }
+            post {
+                always {
+                    sh '''
+		        export NS=test-sample-${BUILD_NUMBER}
+                        helm delete --purge $(helm ls --namespace $NS --short) || true
+                        kubectl delete namespace $NS || true
+                        kubectl delete crd --ignore-not-found=true alertmanagers.monitoring.coreos.com   || true
+                        kubectl delete crd --ignore-not-found=true prometheuses.monitoring.coreos.com    || true
+                        kubectl delete crd --ignore-not-found=true prometheusrules.monitoring.coreos.com || true
+                        kubectl delete crd --ignore-not-found=true servicemonitors.monitoring.coreos.com || true
+                        helm tiller stop || true
+			helm repo remove coherence
+                    '''
+                    deleteDir()
+                }
+            }
+        }
+    }
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -347,6 +347,5 @@ Remove the `coherence` release:
 
 ```
 $ helm delete --purge sample-coherence sample-coherence-operator
-$ kubectl delete configmap coherence-internal-config
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ The Coherence Kubernetes Operator manages Coherence through Kubernetes,
 monitoring MBean attributes through Prometheus and server logs through
 ElasticSearch and Kibana.
 
-> Note, use of Prometheus and Grafana is only available when using the
+> **Note**: use of Prometheus and Grafana is only available when using the
 > operator with Coherence version 12.2.1.4.
 
 Use this quick start guide to deploy Coherence applications in a
@@ -72,10 +72,11 @@ Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "coherence" chart repository
 ```
 
-> **Note**: For all helm install commands you can leave the `--version` option off and the
-> latest version of the chart will be retrieved. 
-> If you wanted to use a specific version, such as `0.9.3`, add `--version 0.9.3` to all installs for the `coherence-operator` and 
-> `coherence` charts.
+> **Note**: For all helm install commands you can leave the `--version`
+> option off and the latest version of the chart will be retrieved.  If
+> you wanted to use a specific version, such as `0.9.3`, add `--version
+> 0.9.3` to all installs for the `coherence-operator` and `coherence`
+> charts.
 
 If you wish to build the Coherence Operator from source, please refer to the 
 [Developer Guide](developer.md) and ensure you replace `coherence` 
@@ -83,7 +84,8 @@ Helm repository prefix in all samples with the full qualified directory as descr
 
 ### Obtain the Coherence Docker Image
 
-> Note: we are assuming Coherence version 12.2.1.3 (which is the currently supported version).
+> **Note**: we are assuming Coherence version 12.2.1.3 (which is the
+> currently supported version).
 
 You must follow the instructions below to obtain the relevant Coherence Docker image.
 
@@ -105,6 +107,8 @@ You must follow the instructions below to obtain the relevant Coherence Docker i
 
 1. Consider whether or not you want to check the `Please keep me
    informed of products, services and solutions from this Publisher` box.
+   
+1. Click "Get Content"
 
 1. At the command line, do `docker login` with your Docker store credentials.
 
@@ -130,9 +134,9 @@ $ helm --debug install coherence/coherence-operator \
     --set imagePullSecrets=sample-coherence-secret
 ``` 
 
-**Note**: Remove the `--debug` option if you do not want very verbose
-output.  Please consult the `values.yaml` in the chart for important
-information regarding the `--set targetNamespaces` argument.
+> **Note**: Remove the `--debug` option if you do not want very verbose
+> output.  Please consult the `values.yaml` in the chart for important
+> information regarding the `--set targetNamespaces` argument.
 
 If the operation completes successfully, you should see output similar to the following.
 
@@ -184,6 +188,12 @@ $ helm --debug install coherence/coherence \
     --name sample-coherence \
     --set imagePullSecrets=sample-coherence-secret
 ``` 
+
+> **Note**: If you want to use a different version of Coherence than the
+> one specified in the `coherence` helm chart, supply a `--set` argument
+> for the `coherence.image` value, as shown next.
+
+> `--set coherence.image="store/oracle/coherence:12.2.1.3.2"`
 
 > Use the command `helm inspect readme <chart name>` to print out the
 > `README.md` of the chart.  For example `helm inspect readme

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -333,6 +333,14 @@ Running the program again should produce:
 The value of the key is 2
 ```
 
+> **Note**: If you are using JDK 11 or newer, you can omit the `javac`
+> step and simply run the program as shown next.
+
+```
+$ java -cp $${COHERENCE_HOME}/lib/coherence.jar \
+  -Dcoherence.cacheconfig=$PWD/example-client-config.xml  HelloCoherence.java
+```
+
 ## 5. Use Helm to delete Coherence and the Operator
 
 Remove the `coherence` release:

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -71,7 +71,9 @@ Ensure you have the following installed:
 
 * Maven 3.5.4+
 
-> Note: You may use a later version od Java, e.g. JDK11 as the maven.compiler.source and target are set to 8.
+> Note: You may use a later version of Java, e.g. JDK11 as the
+> `maven.compiler.source` and `target` are set to 8 in the sample
+> `pom.xml` files.
 
 ## Ensure you install Coherence into your local Maven repository
 
@@ -96,13 +98,6 @@ If you are not running samples that have a Maven project, then you can skip this
                               -DpomFile=$COHERENCE_HOME/plugins/maven/com/oracle/coherence/coherence-rest/12.2.1/coherence-rest.12.2.1.pom
    ```   
 
-1. Ensure that the [samples top level pom.xml](pom.xml) has the Coherence version set to the version you
-   are using:  E.g. if you have Coherence 12.2.1.3.2 then `coherence.version` should be:
-
-   ```xml
-    <coherence.version>12.2.1-3-2</coherence.version>
-   ```
-
 ## Create the sample namespace
 
 You should only need to carry out the following the first time you
@@ -116,10 +111,15 @@ run any of the samples.
   namespace/sample-coherence-ns created
   ```
 
-* Create a secret for pulling images from private repositories
+* Enable Kubernetes to pull docker images from private docker
+  repositories by creating a "secret"
 
-  If you are pulling images from private repositories, you must create a secret
-  which will be used for this. In these samples we are assuming you have created a secret called `sample-coherence-secret` in your namespace `sample-coherence-ns`.
+  If you must enable your Kubernetes cluster to pull images from private
+  repositories, you must create a "secret" to convey the docker
+  credentials to Kubernetes. In these samples we are assuming you have
+  created a secret called `sample-coherence-secret` in your namespace
+  `sample-coherence-ns`.  If all of your images can be pulled from
+  public repositories, this step is not required.
 
   See [https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more information.
 
@@ -147,10 +147,23 @@ $ git checkout gh-pages
 $ cd docs/samples
 ```
 
+1. Inspect the [samples top level pom.xml](pom.xml) to see if you must
+   override the specified `coherence.version` property so that its value
+   matches the version you are actaully using: E.g. if you have
+   Coherence 12.2.1.3.2, but the `pom.xml` has:
+
+   ```xml
+    <coherence.version>12.2.1-3-0</coherence.version>
+   ```
+
+   Then you must provide `-Dcoherence.version=12.2.1-3-2` to every
+   invocation of `mvn`.
+
 Issue the following to ensure all the projects with source code build ok. 
 
-> Note: Any compilation errors will most likely indicate that the Coherence JAR's 
-> are not properly installed or you have not set your JDK.
+> **Note**: Any compilation errors will most likely indicate that the
+> Coherence JAR's are not properly installed or you have not set your
+> JDK.
 
 ```bash
 $ mvn clean install
@@ -166,7 +179,7 @@ When you install the `coherence-operator` you can optionally enable the followin
 1. Prometheus integration to capture metrics and display in Grafana. (Only available from Coherence 12.2.1.4.0 and above)
 
 1. Log capture which will use Fluentd to send logs to Elasticsearch where
-   they key be vied in Kiabana.
+   they key be viewed in Kiabana.
 
 Enabling both Prometheus and log capture will require considerable extra system resources.
 

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -147,6 +147,7 @@ $ git checkout gh-pages
 $ cd docs/samples
 ```
 
+<<<<<<< HEAD
 1. Inspect the [samples top level pom.xml](pom.xml) to see if you must
    override the specified `coherence.version` property so that its value
    matches the version you are actaully using: E.g. if you have
@@ -158,6 +159,14 @@ $ cd docs/samples
 
    Then you must provide `-Dcoherence.version=12.2.1-3-2` to every
    invocation of `mvn`.
+=======
+1. Inspect the [samples top level pom.xml](pom.xml) and verify that the
+   value of the `coherence.version` property matches the version of
+   Coherence you are actaully using. For example if you have Coherence
+   12.2.1.3.0 then the value of `coherence.version` must be
+   `12.2.1-3-0`.  If this value needs ajustment, use the
+   `-Dcoherence.version=` argument to all invocations of `mvn`.
+>>>>>>> #126 Address comments from Manfred and Tim.
 
 Issue the following to ensure all the projects with source code build ok. 
 
@@ -176,10 +185,11 @@ This can be done once and can keep running for all the samples.
 
 When you install the `coherence-operator` you can optionally enable the following:
 
-1. Prometheus integration to capture metrics and display in Grafana. (Only available from Coherence 12.2.1.4.0 and above)
+1. Prometheus integration: to capture metrics and display in
+   Grafana. (Only available from Coherence 12.2.1.4.0 and above)
 
-1. Log capture which will use Fluentd to send logs to Elasticsearch where
-   they key be viewed in Kiabana.
+1. Log capture: to use Fluentd to send logs to Elasticsearch where they
+   can be viewed in Kiabana.
 
 Enabling both Prometheus and log capture will require considerable extra system resources.
 

--- a/docs/samples/coherence-deployments/extend/default/pom.xml
+++ b/docs/samples/coherence-deployments/extend/default/pom.xml
@@ -39,9 +39,60 @@
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>com.oracle.coherence.kubernetes</groupId>
+      <artifactId>samples-testing-support</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.bedrock</groupId>
+      <artifactId>bedrock-runtime-k8s</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+    <testResources>
+      <!-- process values/*.yaml test resources with filtering -->
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
     <plugins>
       <!-- run QueryPlus via mvn exec:java -->
       <plugin>

--- a/docs/samples/coherence-deployments/extend/default/src/test/java/com/oracle/coherence/examples/testing/DefaultProxySampleIT.java
+++ b/docs/samples/coherence-deployments/extend/default/src/test/java/com/oracle/coherence/examples/testing/DefaultProxySampleIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.examples.testing;
+
+import com.oracle.bedrock.runtime.Application;
+
+import com.oracle.bedrock.testsupport.deferred.Eventually;
+import com.tangosol.net.ConfigurableCacheFactory;
+import com.tangosol.net.NamedCache;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+/**
+ * Test the default-proxy-sample.
+ *
+ * Any changes to the arguments of the helm install commands in the README.md, should be
+ * also made to the coherence.yaml file.
+ *
+ * @author tam  2019.05.14
+ */
+@RunWith(Parameterized.class)
+public class DefaultProxySampleIT
+        extends BaseProxySampleTest
+    {
+
+    // ----- constructor ----------------------------------------------------
+
+    /**
+     * Constructor for Parameterized test
+     *
+     * @param sOperatorChartURL   Operator chart URL
+     * @param sCoherenceChartURL  Coherence chart URL
+     */
+    public DefaultProxySampleIT(String sOperatorChartURL, String sCoherenceChartURL)
+        {
+        super(sOperatorChartURL, sCoherenceChartURL);
+        }
+
+    // ----- test lifecycle -------------------------------------------------
+
+    @Parameterized.Parameters
+    public static Collection testParameters()
+        {
+        return buildTestParameters();
+        }
+    
+    /**
+     * Install the charts required for the test.
+     * 
+     * @throws Exception
+     */
+    @Before
+    public void installCharts() throws Exception
+        {
+        if (testShouldRun())
+            {
+            // install Coherence Operator chart
+            s_sOperatorRelease = installOperator("coherence-operator.yaml",toURL(m_sOperatorChartURL));
+
+            // install Coherence chart
+            String[] asCohNamespaces = getTargetNamespaces();
+
+            m_asReleases = installCoherence(s_k8sCluster, toURL(m_sCoherenceChartURL), asCohNamespaces,"coherence.yaml");
+
+            assertCoherence(s_k8sCluster, asCohNamespaces, m_asReleases);
+            }
+        }
+
+    // ----- tests ----------------------------------------------------------
+
+    /**
+     * Test the default proxy sample.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultProxySample() throws Exception
+        {
+        if (testShouldRun())
+            {
+            // test proxy connection to coherence pod
+            testProxyConnection(m_asReleases[0]);
+            }
+        }
+    }

--- a/docs/samples/coherence-deployments/extend/default/src/test/resources/coherence-operator.yaml
+++ b/docs/samples/coherence-deployments/extend/default/src/test/resources/coherence-operator.yaml
@@ -1,0 +1,3 @@
+# Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+
+targetNamespaces: [ ${k8s.target.namespaces} ]

--- a/docs/samples/coherence-deployments/extend/default/src/test/resources/coherence.yaml
+++ b/docs/samples/coherence-deployments/extend/default/src/test/resources/coherence.yaml
@@ -1,0 +1,17 @@
+# Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Any changes in the helm install commands in README must be changed here
+
+clusterSize: 3
+
+cluster: storage-tier-cluster
+
+imagePullSecrets: sample-coherence-secret
+
+logCaptureEnabled: false
+
+prometheusoperator:
+  enabled: false
+
+# Temporary until 0.9.5 released
+coherence:
+  image: ${coherence.image.prefix}coherence:${coherence.docker.version}

--- a/docs/samples/coherence-deployments/extend/proxy-tier/README.md
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/README.md
@@ -97,7 +97,7 @@ Ensure you have already installed the Coherence Operator by using the instructio
      --set clusterSize=1 \
      --set store.storageEnabled=false \
      --set store.wka=storage-coherence-headless \
-     --set prometheusoperator.enabled=true \
+     --set prometheusoperator.enabled=false \
      --name proxy-tier \
      --set imagePullSecrets=sample-coherence-secret \
      --set store.cacheConfig=proxy-cache-config.xml \

--- a/docs/samples/coherence-deployments/extend/proxy-tier/pom.xml
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/pom.xml
@@ -39,9 +39,60 @@
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>com.oracle.coherence.kubernetes</groupId>
+      <artifactId>samples-testing-support</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.bedrock</groupId>
+      <artifactId>bedrock-runtime-k8s</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+    <testResources>
+      <!-- process values/*.yaml test resources with filtering -->
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
     <!-- Use the assembly plugin to pull together the files to use to build the
          docker image under the target/docker folder -->
     <plugins>
@@ -129,9 +180,7 @@
                   <arguments>
                     <argument>build</argument>
                     <argument>-t</argument>
-                    <argument>
-                      ${project.artifactId}:${project.version}
-                    </argument>
+                    <argument>${project.artifactId}:${project.version}</argument>
                     <argument>.</argument>
                   </arguments>
                 </configuration>
@@ -153,6 +202,55 @@
                     </argument>
                     <argument>${project.artifactId}:latest
                     </argument>
+                  </arguments>
+                </configuration>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- used for integration tests only -->
+    <profile>
+      <id>dockerPush</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>tag-for-push</id>
+                <phase>install</phase>
+                <configuration>
+                  <executable>docker</executable>
+                  <workingDirectory>${project.build.directory}/docker</workingDirectory>
+                  <arguments>
+                    <argument>tag</argument>
+                    <argument>${project.artifactId}:${project.version}</argument>
+                    <argument>${docker.push.tag.prefix}${project.artifactId}:${project.version}</argument>
+                  </arguments>
+                </configuration>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-push-explicit-version</id>
+                <phase>install</phase>
+                <configuration>
+                  <executable>docker</executable>
+                  <workingDirectory>${project.build.directory}/docker</workingDirectory>
+                  <arguments>
+                    <argument>push</argument>
+                    <argument>${docker.push.tag.prefix}${project.artifactId}:${project.version}</argument>
                   </arguments>
                 </configuration>
                 <goals>

--- a/docs/samples/coherence-deployments/extend/proxy-tier/src/test/java/com/oracle/coherence/examples/testing/ProxyTierSampleIT.java
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/src/test/java/com/oracle/coherence/examples/testing/ProxyTierSampleIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.examples.testing;
+
+import com.oracle.bedrock.runtime.Application;
+import com.oracle.bedrock.testsupport.deferred.Eventually;
+import com.tangosol.net.ConfigurableCacheFactory;
+import com.tangosol.net.NamedCache;
+import com.tangosol.util.Resources;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test the proxy-tier-sample.
+ *
+ * Any changes to the arguments of the helm install commands in the README.md, should be
+ * also made to the coherence.yaml file.
+ *
+ * @author tam  2019.05.14
+ */
+@RunWith(Parameterized.class)
+public class ProxyTierSampleIT
+        extends BaseProxySampleTest
+    {
+
+    // ----- constructor ----------------------------------------------------
+
+    /**
+     * Constructor for Parameterized test
+     *
+     * @param sOperatorChartURL   Operator chart URL
+     * @param sCoherenceChartURL  Coherence chart URL
+     */
+    public ProxyTierSampleIT(String sOperatorChartURL, String sCoherenceChartURL)
+        {
+        super(sOperatorChartURL, sCoherenceChartURL);
+        }
+    
+    // ----- test lifecycle -------------------------------------------------
+
+    @Parameterized.Parameters
+    public static Collection testParameters()
+        {
+        return buildTestParameters();
+        }
+
+    /**
+     * Install the charts required for the test.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void installCharts() throws Exception
+        {
+        if (testShouldRun())
+            {
+            // install Coherence Operator chart
+            s_sOperatorRelease = installOperator("coherence-operator.yaml",toURL(m_sOperatorChartURL));
+
+            // install Coherence chart
+            String sCohNamespace = getTargetNamespaces()[0];
+
+            String sTag = System.getProperty("docker.push.tag.prefix") + System.getProperty("project.artifactId") + ":" +
+                          System.getProperty("project.version");
+
+            // process yaml file to replace user artifacts image
+            String sProcessedCoherenceYaml = getProcessedYamlFile("coherence.yaml", sTag, null);
+            assertThat(sProcessedCoherenceYaml, is(notNullValue()));
+
+            String sClusterRelease = installCoherence(s_k8sCluster, toURL(m_sCoherenceChartURL), sCohNamespace, sProcessedCoherenceYaml);
+            assertCoherence(s_k8sCluster, sCohNamespace, sClusterRelease);
+
+            // process yaml file for proxy tier
+            String sProcessedProxyYaml = getProcessedYamlFile("coherence-proxy-tier.yaml", sTag, sClusterRelease);
+            assertThat(sProcessedProxyYaml, is(notNullValue()));
+
+            String sProxyRelease = installCoherence(s_k8sCluster, toURL(m_sCoherenceChartURL), sCohNamespace, sProcessedProxyYaml);
+            assertCoherence(s_k8sCluster,sCohNamespace, sProxyRelease);
+
+            m_asReleases = new String[] { sClusterRelease, sProxyRelease };
+            }
+        }
+
+    // ----- tests ----------------------------------------------------------
+
+    /**
+     * Test the proxy tier sample.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testProxyTierSample() throws Exception
+        {
+        if (testShouldRun())
+            {
+            // connect to proxy tier - m_asReleases[1]
+            testProxyConnection(m_asReleases[1]);
+            }
+        }
+    }

--- a/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence-operator.yaml
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence-operator.yaml
@@ -1,0 +1,3 @@
+# Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+
+targetNamespaces: [ ${k8s.target.namespaces} ]

--- a/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence-proxy-tier.yaml
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence-proxy-tier.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Any changes in the helm install commands in README must be changed here
+
+clusterSize: 1
+
+cluster: proxy-tier-cluster
+
+store:
+  cacheConfig: proxy-cache-config.xml
+  storageEnabled: false
+  wka: %%RELEASE_NAME%%-coherence-headless
+
+userArtifacts:
+  image: %%USER_ARTIFACTS_IMAGE%%
+
+imagePullSecrets: sample-coherence-secret
+
+logCaptureEnabled: false
+
+prometheusoperator:
+  enabled: false
+
+# Temporary until 0.9.5 released
+coherence:
+  image: ${coherence.image.prefix}coherence:${coherence.docker.version}

--- a/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence.yaml
+++ b/docs/samples/coherence-deployments/extend/proxy-tier/src/test/resources/coherence.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Any changes in the helm install commands in README must be changed here
+
+clusterSize: 3
+
+cluster: proxy-tier-cluster
+
+store:
+  cacheConfig: storage-cache-config.xml
+
+userArtifacts:
+  image: %%USER_ARTIFACTS_IMAGE%%
+
+imagePullSecrets: sample-coherence-secret
+
+logCaptureEnabled: false
+
+prometheusoperator:
+  enabled: false
+
+# Temporary until 0.9.5 released
+coherence:
+  image: ${coherence.image.prefix}coherence:${coherence.docker.version}

--- a/docs/samples/coherence-deployments/storage-disabled/other/pom.xml
+++ b/docs/samples/coherence-deployments/storage-disabled/other/pom.xml
@@ -103,7 +103,6 @@
           <plugin>
             <groupId>com.google.cloud.tools</groupId>
             <artifactId>jib-maven-plugin</artifactId>
-            <version>${maven.jib.plugin.version}</version>
             <configuration>
               <to>
                 <image>${project.artifactId}</image>

--- a/docs/samples/coherence-deployments/storage-disabled/other/src/main/java/com/oracle/coherence/examples/Main.java
+++ b/docs/samples/coherence-deployments/storage-disabled/other/src/main/java/com/oracle/coherence/examples/Main.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
 package com.oracle.coherence.examples;
 
 import com.tangosol.net.CacheFactory;

--- a/docs/samples/operator/logging/custom-logs/README.md
+++ b/docs/samples/operator/logging/custom-logs/README.md
@@ -36,29 +36,22 @@ Ensure you have already installed the Coherence Operator with `--set logCaptureE
    mvn clean install -P docker
    ```
 
-   The above will build the Docker image with the cache and login configuration as well as compiled Java classes
+   The above will build the Docker image with the cache and logging
+   configuration as well as compiled Java classes.
    
    > Note: If you are running against a remote Kubernetes cluster you
    > will need to push the above image to your repository accessible to
    > that cluster. You will also need to prefix the image name in your
    > `helm` command below.
    
-   > Look something that looks like the string `Successfully tagged
-   > custom-logger-sample:1.0.0-SNAPSHOT` 
+   > In the build output, look for something that looks like `Successfully tagged
+   > custom-logger-sample:1.0.0-SNAPSHOT`.  Refer to the steps in [the top level README of the samples](../../../README.md#using-dockerhub-for-your-images).
+   > Create a repository within your DockerHub account called
+   > `custom-logger-samples`.  Retag your image as
    
+   > `docker tag custom-logger-sample:1.0.0-SNAPSHOT mydockerid/custom-logger-samples:1.0.0-SNAPSHOT`
    
-
-1. The result of the above is the docker image will be built with the cache configuration files
-   and compiled Java classes with the name in the format custom-logger-sample:{version}.
-
-   For Example:
-
-   ```bash
-   custom-logger-sample:1.0.0-SNAPSHOT
-   ```
-
-   **Note:** If you are running against a remote Kubernetes cluster you will need to
-   push the above image to your repository accessible to that cluster.
+   > Then push it with `docker push mydockerid/custom-logger-samples:1.0.0-SNAPSHOT`.
 
 1. Install the Coherence cluster
 
@@ -66,7 +59,7 @@ Ensure you have already installed the Coherence Operator with `--set logCaptureE
    
    * `--set logCaptureEnabled=true` - enable log catpure
    
-   * `--set userArtifacts.image=custom-logger-sample:1.0.0-SNAPSHOT` - custom image with config and classes
+   * `--set userArtifacts.image=custom-logger-sample:1.0.0-SNAPSHOT` - custom image with config and classes.  If you are using a remote Kubernetes cluster, the value of this option must be the Docker image that can be pulled by the cluster.  For example, `mydockerid/custom-logger-samples:1.0.0-SNAPSHOT`.
    
    * `--set store.logging.configFile=custom-logging.properties` - configure custom logger
    
@@ -104,7 +97,7 @@ Ensure you have already installed the Coherence Operator with `--set logCaptureE
    storage-coherence-2                   2/2     Running   0          1m
    ```
           
-1. Port forward the proxy port on the storage-coherence-0 pod.
+1. Port forward the Coherence proxy port on the storage-coherence-0 pod.
 
    ```bash
    $ kubectl port-forward -n sample-coherence-ns storage-coherence-0 20000:20000
@@ -162,7 +155,8 @@ Ensure you have already installed the Coherence Operator with `--set logCaptureE
 
    * After logging in, click on `Management`, `Index Patterns` the `Create index pattern`.
    
-   * Set the name to `cloud-*`. This show that this matches 1 index such as `cloud-2019.04.29`.
+   * Set the name to `cloud-*`. This will show that this matches 1 index
+     such as `cloud-2019.04.29`.
    
    * Click `Next Step` and select the `@timestamp` field and click on `Create index pattern`.
    

--- a/docs/samples/operator/logging/custom-logs/README.md
+++ b/docs/samples/operator/logging/custom-logs/README.md
@@ -38,9 +38,15 @@ Ensure you have already installed the Coherence Operator with `--set logCaptureE
 
    The above will build the Docker image with the cache and login configuration as well as compiled Java classes
    
-   > Note: If you are running against a remote Kubernetes cluster you will need to
-   > push the above image to your repository accessible to that cluster. You will also need to 
-   > prefix the image name in your `helm` command below.
+   > Note: If you are running against a remote Kubernetes cluster you
+   > will need to push the above image to your repository accessible to
+   > that cluster. You will also need to prefix the image name in your
+   > `helm` command below.
+   
+   > Look something that looks like the string `Successfully tagged
+   > custom-logger-sample:1.0.0-SNAPSHOT` 
+   
+   
 
 1. The result of the above is the docker image will be built with the cache configuration files
    and compiled Java classes with the name in the format custom-logger-sample:{version}.

--- a/docs/samples/operator/logging/log-capture/README.md
+++ b/docs/samples/operator/logging/log-capture/README.md
@@ -110,9 +110,9 @@ Use the `port-forward-kibana.sh` script in the
    
    >Note: It may take up to 5 minutes for the data to reach the elasticsearch instance.   
    
-## Default Dashboards
+## Default Kibana Dashboards
 
-There are a number of dashboard created via the import process.
+There are a number of Kibana dashboards created via the import process.
 
 **Coherence Operator**
 

--- a/docs/samples/pom.xml
+++ b/docs/samples/pom.xml
@@ -22,6 +22,7 @@
   <name>Samples Parent</name>
 
   <modules>
+    <module>testing-support</module>
     <module>coherence-deployments/extend/proxy-tier</module>
     <module>coherence-deployments/extend/multiple</module>
     <module>coherence-deployments/extend/default</module>
@@ -44,24 +45,81 @@
 
     <!-- library dependency versions -->
     <bedrock.version>5.0.10</bedrock.version>
+    <commons.compress.version>1.18</commons.compress.version>
     <hamcrest.version>1.3</hamcrest.version>
     <helidon.version>1.0.0</helidon.version>
+    <glassfish.jmxmp.version>1.0-b01-ea</glassfish.jmxmp.version>
+    <jackson.version>2.9.8</jackson.version>
     <jline.version>2.14.6</jline.version>
     <junit.version>4.12</junit.version>
+    <javax.activation.version>1.2.0</javax.activation.version>
+    <javax.xml.bind.version>2.3.0</javax.xml.bind.version>
+    <jersey.version>2.25</jersey.version>
     <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
     <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
     <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
     <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>
+    <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
     <maven.jib.plugin.version>1.1.0</maven.jib.plugin.version>
     <maven.resource.plugin.version>3.1.0</maven.resource.plugin.version>
     <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
     <mockito.version>2.18.3</mockito.version>
+    <coherence.version>12.2.1-3-0</coherence.version>
 
-    <!-- change this to match your Coherence version
-         Must be 12.2.1.3-2 or above -->
-    <coherence.version>12.2.1-3-2</coherence.version>
+    <!--- test properties -->
+    <ci.build>${env.CI_BUILD_ID}</ci.build>
+    <!-- Set the namespace from the CI build id to ensure tests use a unique namespace -->
+    <k8s.namespace>test-sample-${ci.build}</k8s.namespace>
+    <!-- Set the target namespaces for coherence -->
+    <k8s.target.namespaces>test-sample-${ci.build}</k8s.target.namespaces>
+    <!-- the k8s configuration file to use (default to ~/.kube/config) -->
+    <k8s.config/>
+    <!-- the k8s context to use (defaults to the current context) -->
+    <k8s.context/>
+    <!-- the k8s docker-registry secret name continuing the image pull credentials -->
+    <k8s.image.pull.secret/>
+    <!--&lt;!&ndash; flag indicating whether to create the pull secrets &ndash;&gt;-->
+    <k8s.create.secret>false</k8s.create.secret>
+    <!-- the username to use when creating pull secrets -->
+    <k8s.secret.user/>
+    <!-- the email to use when creating pull secrets -->
+    <k8s.secret.email/>
+    <!-- the location of the Kubernetes CLI (default to /usr/local/bin/kubectl in Bedrock) -->
+    <k8s.kubectl/>
+    <!-- the credentials (wcr token) to use when creating pull secrets -->
+    <k8s.secret.credentials/>
+    <!-- flag indicating whether to create and destroy the k8s namespace used for testing -->
+    <k8s.create.namespace>true</k8s.create.namespace>
+    <!-- minimiun port used for k8s port forward, note that by default k8s uses 30000-32767 for node port -->
+    <k8s.min.forward.port>40000</k8s.min.forward.port>
+    <!-- the timeout for Helm commands (in seconds) -->
+    <helm.timeout>300</helm.timeout>
+    <!-- location of the Helm config (default "~/.helm") -->
+    <helm.home/>
+    <!-- the address of Tiller. -->
+    <helm.tiller.host/>
+    <!-- The k8s namespace that Tiller is running in -->
+    <helm.tiller.namespace/>
+    <!-- the name of the Operator Helm chart to test -->
+    <operator.helm.chart.name>coherence-operator</operator.helm.chart.name>
+    <!-- the name of the Coherence Helm chart to test -->
+    <coherence.helm.chart.name>coherence</coherence.helm.chart.name>
+    <!-- the helm chart repository base to test-->
+    <k8s.coherence.chart.repo></k8s.coherence.chart.repo>
+    <!-- the helm chart versions to test -->
+    <k8s.chart.test.versions></k8s.chart.test.versions>
+    <!-- the location of the Helm CLI (default to /usr/local/bin/helm) -->
+    <bedrock.helm>/usr/local/bin/helm</bedrock.helm>
+    <!-- the image pull policy for Coherence Operator -->
+    <op.image.pull.policy/>
+
+    <coherence.image.prefix></coherence.image.prefix>
+    <!-- interim version until chart version is corectly pullable -->
+    <coherence.docker.version>12.2.1.3</coherence.docker.version>
+    <release.image.prefix>${test.image.prefix}</release.image.prefix>
+    <docker.push.tag.prefix>${release.image.prefix}oracle/</docker.push.tag.prefix>
   </properties>
 
   <dependencyManagement>
@@ -165,6 +223,51 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-client</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-jackson</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish.external</groupId>
+        <artifactId>opendmk_jmxremote_optional_jar</artifactId>
+        <version>${glassfish.jmxmp.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${javax.xml.bind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>javax.activation</artifactId>
+        <version>${javax.activation.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -212,7 +315,13 @@
               </goals>
             </execution>
           </executions>
-         </plugin>
+        </plugin>
+
+        <plugin>
+          <groupId>com.google.cloud.tools</groupId>
+          <artifactId>jib-maven-plugin</artifactId>
+          <version>${maven.jib.plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     
@@ -228,6 +337,76 @@
        </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- The Helm testing profile -->
+      <id>helm-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <encoding>UTF-8</encoding>
+              <failIfNoTests>false</failIfNoTests>
+              <useSystemClassLoader>true</useSystemClassLoader>
+              <useManifestOnlyJar>false</useManifestOnlyJar>
+              <systemProperties>
+                <k8s.namespace>${k8s.namespace}</k8s.namespace>
+                <k8s.target.namespaces>${k8s.target.namespaces}</k8s.target.namespaces>
+                <k8s.config>${k8s.config}</k8s.config>
+                <k8s.context>${k8s.context}</k8s.context>
+                <k8s.image.pull.secret>${k8s.image.pull.secret}</k8s.image.pull.secret>
+                <k8s.create.namespace>${k8s.create.namespace}</k8s.create.namespace>
+                <k8s.create.secret>${k8s.create.secret}</k8s.create.secret>
+                <k8s.kubectl>${k8s.kubectl}</k8s.kubectl>
+                <k8s.secret.user>${k8s.secret.user}</k8s.secret.user>
+                <k8s.secret.credentials>${k8s.secret.credentials}</k8s.secret.credentials>
+                <k8s.secret.email>${k8s.secret.email}</k8s.secret.email>
+                <k8s.min.forward.port>${k8s.min.forward.port}</k8s.min.forward.port>
+                <helm.timeout>${helm.timeout}</helm.timeout>
+                <helm.home>${helm.home}</helm.home>
+                <helm.tiller.host>${helm.tiller.host}</helm.tiller.host>
+                <helm.tiller.namespace>${helm.tiller.namespace}</helm.tiller.namespace>
+                <operator.helm.chart.package>${operator.helm.chart.package}</operator.helm.chart.package>
+                <operator.helm.chart.name>${operator.helm.chart.name}</operator.helm.chart.name>
+                <coherence.helm.chart.package>${coherence.helm.chart.package}</coherence.helm.chart.package>
+                <coherence.helm.chart.name>${coherence.helm.chart.name}</coherence.helm.chart.name>
+                <bedrock.helm>${bedrock.helm}</bedrock.helm>
+                <op.image.pull.policy>${op.image.pull.policy}</op.image.pull.policy>
+                <project.build.directory>${project.build.directory}</project.build.directory>
+                <docker.repo>${test.image.prefix}</docker.repo>
+                <test.image.prefix>${test.image.prefix}</test.image.prefix>
+                <http.proxyHost>${settings.proxies[0].host}</http.proxyHost>
+                <https.proxyHost>${settings.proxies[0].host}</https.proxyHost>
+                <http.proxyPort>${settings.proxies[0].port}</http.proxyPort>
+                <https.proxyPort>${settings.proxies[0].port}</https.proxyPort>
+                <http.nonProxyHosts>${settings.proxies[0].nonProxyHosts}</http.nonProxyHosts>
+                <docker.push.tag.prefix>${docker.push.tag.prefix}</docker.push.tag.prefix>
+                <project.artifactId>${project.artifactId}</project.artifactId>
+                <project.version>${project.version}</project.version>
+              </systemProperties>
+              <includes>
+                <include>/**/*IT.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <developers>
     <developer>

--- a/docs/samples/testing-support/pom.xml
+++ b/docs/samples/testing-support/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+    Licensed under the Universal Permissive License v 1.0 as shown at
+    http://oss.oracle.com/licenses/upl.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.oracle.coherence.kubernetes</groupId>
+    <artifactId>samples-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>samples-testing-support</artifactId>
+  <name>Samples Testing Support</name>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <user.artifacts.image>${test.image.prefix}user-artifacts</user.artifacts.image>
+    <user.artifacts.image.v1>1.0</user.artifacts.image.v1>
+    <user.artifacts.image.v2>2.0</user.artifacts.image.v2>
+    <user.test.image>${test.image.prefix}coh-client</user.test.image>
+    <user.test.image.version>2.0</user.test.image.version>
+    <user.fluentd.image>${test.image.prefix}fluentd</user.fluentd.image>
+    <user.fluentd.image.version>2.0</user.fluentd.image.version>
+    <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.coherence</groupId>
+      <artifactId>coherence</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${javax.ws.rs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.external</groupId>
+      <artifactId>opendmk_jmxremote_optional_jar</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.bedrock</groupId>
+      <artifactId>bedrock-runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.bedrock</groupId>
+      <artifactId>bedrock-runtime-docker</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.bedrock</groupId>
+      <artifactId>bedrock-runtime-k8s</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.oracle.coherence</groupId>
+      <artifactId>coherence-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.coherence.kubernetes</groupId>
+      <artifactId>coherence-utils</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven.jar.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  
+</project>

--- a/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/BaseHelmChartTest.java
+++ b/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/BaseHelmChartTest.java
@@ -1,0 +1,2614 @@
+package com.oracle.coherence.examples.testing;
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oracle.bedrock.deferred.options.RetryFrequency;
+import com.oracle.bedrock.options.LaunchLogging;
+import com.oracle.bedrock.options.Timeout;
+import com.oracle.bedrock.runtime.Application;
+import com.oracle.bedrock.runtime.ApplicationConsole;
+import com.oracle.bedrock.runtime.ApplicationConsoleBuilder;
+import com.oracle.bedrock.runtime.console.CapturingApplicationConsole;
+import com.oracle.bedrock.runtime.console.EventsApplicationConsole;
+import com.oracle.bedrock.runtime.console.FileWriterApplicationConsole;
+import com.oracle.bedrock.runtime.console.SystemApplicationConsole;
+import com.oracle.bedrock.runtime.k8s.K8sCluster;
+import com.oracle.bedrock.runtime.k8s.helm.Helm;
+import com.oracle.bedrock.runtime.k8s.helm.HelmCommand;
+import com.oracle.bedrock.runtime.k8s.helm.HelmInstall;
+import com.oracle.bedrock.runtime.options.Arguments;
+import com.oracle.bedrock.runtime.options.Console;
+import com.oracle.bedrock.runtime.options.DisplayName;
+import com.oracle.bedrock.testsupport.deferred.Eventually;
+import com.oracle.bedrock.testsupport.junit.TestLogs;
+import com.oracle.coherence.k8s.CoherenceVersion;
+import com.tangosol.util.AssertionException;
+import com.tangosol.util.Resources;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
+
+import static com.oracle.coherence.examples.testing.HelmUtils.HELM_TIMEOUT;
+import static com.oracle.coherence.examples.testing.HelmUtils.getK8sObject;
+import static com.oracle.coherence.examples.testing.HelmUtils.getPods;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * A base class for executing Helm chart tests.
+ *
+ * @author jk
+ * @author sc
+ */
+public abstract class BaseHelmChartTest
+    {
+    // ----- test lifecycle -------------------------------------------------
+
+    @Before
+    public void logTestStart()
+        {
+        System.err.println(">>>>>> Starting test " + getClass().getSimpleName() + " " + m_testName.getMethodName()
+                                   + " >>>>>>>>>>>>>>>>");
+        }
+
+    @After
+    public void logTestEnd()
+        {
+        System.err.println("<<<<<< Finished test " + getClass().getSimpleName() + " " + m_testName.getMethodName()
+                                   + " <<<<<<<<<<<<<<<<");
+        }
+
+    // ----- helper methods -------------------------------------------------
+
+       /**
+     * Return a new yaml file with the %%NAME%% tokens replaced.
+     *
+     * @param sValuesFile         values file to process
+     * @param sUserArtifactImage  user artifact image
+     * @param sReleaseName        release name
+     *
+     * @return a new file path
+     */
+    protected String getProcessedYamlFile(String sValuesFile, String sUserArtifactImage, String sReleaseName)
+        {
+        String sYamlFile = Resources.findFileOrResource(sValuesFile, null).getPath();
+
+        assertThat(sYamlFile, is(notNullValue()));
+
+        File fileTemp = null;
+        try
+            {
+            fileTemp            = File.createTempFile("processed",".yaml");
+            String sYamlContent = new String(Files.readAllBytes(Paths.get(sYamlFile)));
+            if (sReleaseName != null)
+                {
+                sYamlContent = sYamlContent.replaceAll(RELEASE_NAME_REGEX, sReleaseName);
+                }
+            if (sUserArtifactImage != null)
+                {
+                sYamlContent = sYamlContent.replaceAll(USER_ARTIFACTS_IMAGE_REGEX, sUserArtifactImage);
+                }
+            Files.write(Paths.get(fileTemp.getPath()), sYamlContent.getBytes());
+            }
+        catch (IOException e)
+            {
+            throw new RuntimeException(e);
+            }
+
+        return fileTemp.getPath();
+        }
+
+    /**
+     * Build a {@link Collection} of operator and Coherence charts to test the samples with.<br/>
+     * Setting -Dk8s.chart.test.versions=0.9.3,0.9.4 would run the tests for the samples against
+     * the two versions.
+     *
+     * @return a {@link Collection} of operator and Coherence charts to test the samples with
+     */
+    protected static Collection buildTestParameters()
+        {
+        String   sCoherenceChartRepo = getCoherenceCharRepository();
+        String[] asChartTestVersions = getChartTestVersions();
+        Object[] aoDiskCharts        = new Object[] { OPERATOR_HELM_CHART_PACKAGE, COHERENCE_HELM_CHART_PACKAGE };
+
+        if (asChartTestVersions == null || asChartTestVersions.length == 0)
+            {
+            // only include the directory based packages
+            return Arrays.asList(new Object[][] { aoDiskCharts });
+            }
+        else
+            {
+            Object[] aoList = new Object[asChartTestVersions.length + 1];
+            // build list of charts to test
+            for (int i = 0; i < asChartTestVersions.length; i++)
+                {
+                aoList[i] = new Object[] {
+                        sCoherenceChartRepo + "/" + OPERATOR_HELM_CHART_NAME  + "-" + asChartTestVersions[i] + ".tgz",
+                        sCoherenceChartRepo + "/" + COHERENCE_HELM_CHART_NAME + "-" + asChartTestVersions[i] + ".tgz"
+                };
+                }
+            // add on the disk based sources, which could be null
+            aoList[asChartTestVersions.length] = aoDiskCharts;
+
+            return Arrays.asList(aoList);
+            }
+        }
+
+    /**
+     * Install the Helm chart.
+     *
+     * @param cluster         the k8s cluster to use
+     * @param sHelmChartName  the Helm chart name
+     * @param sNamespace      the k8s namespace being used
+     * @param sURLValue       the values file to use
+     * @param asSetValues     the array of Helm set values
+     *
+     * @return  the name of the Helm release
+     *
+     * @throws Exception if there is an error
+     */
+    public static String installChart(K8sCluster cluster,
+                                      String     sHelmChartName,
+                                      URL        urlChartPackage,
+                                      String     sNamespace,
+                                      String     sURLValue,
+                                      String...  asSetValues) throws Exception
+        {
+        String[] aURLValues = (sURLValue == null) ? null : new String[] { sURLValue };
+        return installChart(cluster, sHelmChartName, urlChartPackage, sNamespace, aURLValues, asSetValues);
+        }
+
+    /**
+     * Install the Helm chart.
+     *
+     * @param cluster         the k8s cluster to use
+     * @param sHelmChartName  the Helm chart name
+     * @param sNamespace      the k8s namespace being used
+     * @param aURLValues      an array of the values file to use
+     * @param asSetValues     an optional array of Helm set values
+     *
+     * @return  the name of the Helm release
+     *
+     * @throws Exception if there is an error
+     */
+    public static String installChart(K8sCluster cluster,
+                                      String     sHelmChartName,
+                                      URL        urlChartPackage,
+                                      String     sNamespace,
+                                      String[]   aURLValues,
+                                      String...  asSetValues) throws Exception
+        {
+        URL[] aURL = (aURLValues == null) ? null :
+                                            Arrays.stream(aURLValues)
+                                                  .map(BaseHelmChartTest::toURL)
+                                                  .toArray(URL[]::new);
+
+        return installChart(cluster, sHelmChartName, urlChartPackage, sNamespace, aURL, asSetValues);
+        }
+
+    /**
+     * Install the Helm chart.
+     *
+     * @param cluster         the k8s cluster to use
+     * @param sHelmChartName  the Helm chart name
+     * @param urlHelmPackage  the URL of the .tar.gz file containing the chart
+     * @param sNamespace      the k8s namespace being used
+     * @param aURLValues      an array of the values file to use
+     * @param asSetValues     an optional array of Helm set values
+     *
+     * @return  the name of the Helm release
+     *
+     * @throws Exception if there is an error
+     */
+    public static String installChart(K8sCluster cluster,
+                                      String     sHelmChartName,
+                                      URL        urlHelmPackage,
+                                      String     sNamespace,
+                                      URL[]      aURLValues,
+                                      String...  asSetValues) throws Exception
+        {
+        assertPreconditions(cluster);
+
+        assertThat("Chart name is null", sHelmChartName, is(notNullValue()));
+        assertThat("Chart tar.gz package URL is null",  urlHelmPackage, is(notNullValue()));
+
+        // fetch and unzip helm chart
+        File fileChartDir = extractChart(sHelmChartName, urlHelmPackage);
+
+        // helm install dry run and get the release name used for the dry-run
+        String sRelease = installDryRun(fileChartDir, sHelmChartName, sNamespace, aURLValues, asSetValues);
+
+        // helm install real using the release name from the dry-run
+        int nExitCode = install(fileChartDir, sHelmChartName, sNamespace, sRelease, aURLValues, asSetValues);
+
+        if (nExitCode != 0)
+            {
+            try
+                {
+                System.err.println("Clean up Helm install '" + sRelease + "' with exit code " + nExitCode);
+                cleanupHelmReleases(sRelease);
+                cleanupPersistentVolumeClaims(cluster, sRelease, sNamespace);
+                }
+            catch(Throwable t)
+                {
+                System.err.println("Error in clean up Helm release '" + sRelease + "': " + t);
+                }
+
+            throw new Exception("Helm install '" + sRelease + "' failed with exit code: " + nExitCode);
+            }
+
+        // Wait for the StatefulSet to be ready
+        System.err.println("Installed Helm chart - release=" + sRelease);
+
+        return sRelease;
+        }
+
+    /**
+     * Extract a Helm chart .tar.gz file and verify that the chart is valid.
+     *
+     * @param sHelmChartName  the name of the chart
+     * @param urlHelmPackage  the URL of the .tar.gz file
+     *
+     * @return  the directory that the .tar.gz was extracted to
+     *
+     * @throws IOException     if an error occurs extracting the chart
+     * @throws AssertionError  if the chart is not valid
+     */
+    public static File extractChart(String sHelmChartName, URL urlHelmPackage) throws IOException
+        {
+        // fetch and unzip helm chart
+        File fileTempDir = s_temp.newFolder();
+
+        assertThat(fileTempDir.exists(), is(true));
+
+        System.err.println("Extracting Helm chart " + urlHelmPackage + " into " + fileTempDir);
+
+        HelmUtils.extractTarGZ(fileTempDir, urlHelmPackage);
+
+        // Run Helm lint to verify that the chart is valid.
+        assertHelmLint(fileTempDir, sHelmChartName);
+
+        return fileTempDir;
+        }
+
+    /**
+     * Run Helm lint on the chart.
+     *
+     * @param fileDir  the directory containing the chart
+     * @param sChart   the name of the chart
+     */
+    protected static void assertHelmLint(File fileDir, String sChart)
+        {
+        File fileChartDir = new File(fileDir, sChart);
+
+        assertThat(fileChartDir.exists(), is(true));
+        assertThat(fileChartDir.isDirectory(), is(true));
+
+        // Run Helm lint to verify that the chart is valid.
+        int nExitCode = s_helm.lint(fileDir, sChart)
+                          .executeAndWait();
+
+        assertThat("Helm lint failed", nExitCode, is(0));
+        }
+
+    /**
+     * Perform a dry-run install.
+     *
+     * @param fileDir         the directory containing the chart
+     * @param sHelmChartName  the Helm chart name
+     * @param sNamespace      the k8s namespace being used
+     * @param aURLValues      the values files to use
+     * @param asSetValues     an optional array of Helm set values
+     *
+     * @return  the name of the release
+     */
+    protected static String installDryRun(File fileDir, String sHelmChartName, String sNamespace, URL[] aURLValues, String... asSetValues) throws Exception
+        {
+        CapturingApplicationConsole consoleInstall = new CapturingApplicationConsole();
+
+        HelmInstall install = s_helm.install(fileDir, sHelmChartName)
+                                    .dryRun()
+                                    .debug()
+                                    .timeout(HELM_TIMEOUT)
+                                    .set("coherenceK8sOperatorTesting=true")
+                                    .set(asSetValues);
+
+        int nExitCode = install(install, sNamespace, Console.of(consoleInstall), aURLValues);
+
+        if (nExitCode != 0)
+            {
+            HelmUtils.logConsoleOutput("helm-install", consoleInstall);
+            }
+
+        String reason = "Install dry-run failed for helm chart " + sHelmChartName + " namespace " + sNamespace;
+        assertThat(reason, nExitCode, is(0));
+
+        List<String> listLines = new ArrayList<>(consoleInstall.getCapturedOutputLines());
+
+        String sNameLine = listLines.stream()
+                                    .filter(s -> s.startsWith("NAME:"))
+                                    .findFirst()
+                                    .orElse(null);
+
+        assertThat("installDryRun: failed to get a release name", sNameLine, is(notNullValue()));
+
+        String sRelease = sNameLine.substring(5).trim();
+
+        assertThat("installDryRun: failed to get a release name", sRelease.isEmpty(), is(false));
+
+        File   fileRoot = s_testLogs.getOutputFolder();
+        String sName    = "helm-install-" + sRelease;
+        File   fileLog  = new File(fileRoot, sName);
+
+        try (PrintStream out = new PrintStream(fileLog))
+            {
+            HelmUtils.logConsoleOutput(sName, consoleInstall, out);
+            out.flush();
+            }
+
+        return sRelease;
+        }
+
+    /**
+     * Perform a Helm install.
+     *
+     * @param fileDir         the directory containing the chart to install
+     * @param sHelmChartName  the Helm chart name
+     * @param sNamespace      the k8s namespace being used
+     * @param sRelease        the name to use for the release
+     * @param aURLValues      an array of the values files to use
+     * @param asSetValues     an optional array of Helm set values
+     *
+     * @return the exit code of Helm install
+     *
+     * @throws Exception if an error occurs during install
+     */
+    protected static int install(File fileDir, String sHelmChartName, String sNamespace, String sRelease, URL[] aURLValues, String... asSetValues) throws Exception
+        {
+        HelmInstall install = s_helm.install(fileDir, sHelmChartName)
+                                    .set("coherenceK8sOperatorTesting=true")
+                                    .set(asSetValues)
+                                    .timeout(HELM_TIMEOUT)
+                                    .name(sRelease);
+
+        return install(install, sNamespace, SystemApplicationConsole.builder(), aURLValues);
+        }
+
+    /**
+     * Execute a {@link HelmInstall} command.
+     *
+     * @param install     the {@link HelmInstall} command to execute
+     * @param sNamespace  the k8s namespace being used
+     * @param console     the {@link ApplicationConsoleBuilder} to use
+     * @param aURLValues  an optional set of values files to use
+     *
+     * @throws Exception if an error occurs during install
+     */
+    protected static int install(HelmInstall install, String sNamespace, ApplicationConsoleBuilder console, URL... aURLValues) throws Exception
+        {
+        if (aURLValues != null && aURLValues.length > 0)
+            {
+            File file;
+
+            for (URL url : aURLValues)
+                {
+                if ("file".equalsIgnoreCase(url.getProtocol()))
+                    {
+                    file = new File(url.getFile());
+                    }
+                else
+                    {
+                    file = s_temp.newFile("values.yaml");
+                    Files.copy(url.openStream(), file.toPath());
+                    }
+
+                // dump the values to the log
+                System.err.println("Running Helm install using values from " + url);
+                System.err.println("---------------------------------------");
+                Files.lines(file.toPath())
+                        .forEach(System.err::println);
+                System.err.println("---------------------------------------");
+                System.err.flush();
+
+                install = install.values(file);
+                }
+            }
+
+        if (sNamespace != null && sNamespace.trim().length() > 0)
+            {
+            install = install.namespace(sNamespace.trim());
+            }
+
+        if (K8S_IMAGE_PULL_SECRET != null && K8S_IMAGE_PULL_SECRET.trim().length() > 0)
+            {
+            install = install.set("imagePullSecrets={" + K8S_IMAGE_PULL_SECRET + "}");
+            }
+
+        return install.executeAndWait(console);
+        }
+
+    public static void captureInstalledPodLogs(K8sCluster cluster, String sNamespace, String sRelease)
+        {
+        try
+            {
+            CapturingApplicationConsole consolePods       = new CapturingApplicationConsole();
+            CapturingApplicationConsole consoleContainers = new CapturingApplicationConsole();
+            int                         nExitCode;
+
+            nExitCode = cluster.kubectlAndWait(Arguments.of("get", "pods", "--all-namespaces=true", "--selector", "release=" + sRelease,  "-o", "name"),
+                                               Console.of(consolePods),
+                                               LaunchLogging.disabled());
+
+            if (nExitCode != 0)
+                {
+                System.err.println("Cannot obtain Pod names so cannot capture logs");
+                return;
+                }
+
+            Queue<String> queuePods = consolePods.getCapturedOutputLines();
+
+            for (String sPod : queuePods)
+                {
+                if (sPod.equals("(terminated)"))
+                    {
+                    continue;
+                    }
+
+                nExitCode = cluster.kubectlAndWait(Arguments.of("get", sPod, "--all-namespaces=true", "-o", "jsonpath={.spec.containers[*].name}"),
+                                                   Console.of(consoleContainers),
+                                                   LaunchLogging.disabled());
+
+                String[] asContainers;
+
+                if (nExitCode == 0)
+                    {
+                    asContainers = consoleContainers.getCapturedOutputLines().poll().split("\\s");
+                    }
+                else
+                    {
+                    System.err.println("Cannot obtain Pod container names so cannot capture logs");
+                    asContainers = new String[]{null};
+                    }
+
+                for (String sContainer : asContainers)
+                    {
+                    Arguments arguments = Arguments.of("logs", sPod, "-f");
+
+                    if (sNamespace != null)
+                        {
+                        arguments = arguments.with("--namespace", sNamespace);
+                        }
+
+                    if (sContainer != null)
+                        {
+                        arguments = arguments.with("-c", sContainer);
+                        }
+
+                    String sName = sContainer == null ? sPod.substring(4) : sPod.substring(4) + "-" + sContainer;
+
+                    cluster.kubectl(arguments,
+                                    s_testLogs.builder(),
+                                    DisplayName.of(sName),
+                                    LaunchLogging.disabled());
+                    }
+                }
+            }
+        catch (Throwable thrown)
+            {
+            System.err.println("Cannot capure POD logs: " + thrown.getMessage());
+            }
+        }
+
+
+    /**
+     * Obtain all of the k8s resources created for the release.
+     *
+     * @param cluster   the k8s cluster
+     * @param sRelease  the name of the release
+     *
+     * @return a {@link Map} of K8s resources
+     */
+    @SuppressWarnings("unchecked")
+    protected Map<String, ?> getK8sResources(K8sCluster cluster, String sRelease) throws Exception
+        {
+        CapturingApplicationConsole consoleK8sGetAll = new CapturingApplicationConsole();
+
+        cluster.kubectlAndWait(Arguments.of("get", "all", "--selector", "release=" + sRelease,  "-o", "json"),
+                               Console.of(consoleK8sGetAll));
+
+        HelmUtils.logConsoleOutput("kubectl-get", consoleK8sGetAll);
+
+        String sJson  = consoleK8sGetAll.getCapturedOutputLines().stream().collect(Collectors.joining());
+
+        return HelmUtils.JSON_MAPPER.readValue(sJson, Map.class);
+        }
+
+    /**
+     * Assert the test pre-conditions.
+     *
+     * @param cluster  the k8s cluster
+     */
+    protected static void assertPreconditions(K8sCluster cluster)
+        {
+        Assume.assumeThat("The k8s cluster to use has not been set", cluster, is(notNullValue()));
+        Assume.assumeThat("Helm executable " + s_helm.getHelmLocation()
+                                  + " does not exists or is not executable", s_helm.helmExists(), is(true));
+
+        }
+
+    /**
+     * Assert whether the Helm deployment is ready or not (i.e all Pods are ready).
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace being used
+     * @param sSelector   the selector
+     * @param fReady      the readiness of the deployment
+     *
+     * @exception AssertionError  if the deployment is not ready
+     */
+    protected static void assertDeploymentReady(K8sCluster cluster, String sNamespace, String sSelector, boolean fReady)
+        {
+        Eventually.assertThat("assertDeploymentReady namespace=" + sNamespace + " selector=" + sSelector,
+            invoking(STUB).isDeploymentReady(cluster, sNamespace, sSelector), is(fReady),
+                Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));
+        }
+
+    /**
+     * Assert that the Coherence stateful set's service is running.
+     *
+     * @param k8sCluster  the k8s cluster to use
+     * @param sNamespace  the k8s namespace the service is in
+     * @param sRelease    the name of the Helm release
+     */
+    protected void assertCoherenceService(K8sCluster k8sCluster, String sNamespace, String sRelease)
+        {
+        String       sCoherenceServiceSelector = getCoherenceServiceSelector(sRelease);
+        List<String> listSvcs                  = getK8sObject(k8sCluster,
+                                                              "svc",
+                                                              sNamespace,
+                                                              sCoherenceServiceSelector);
+
+        assertThat("assertCoherenceService assertThat Coherence stateful set service is running", listSvcs.size(), is(1));
+
+        String sReleaseName = sRelease + "-" + COHERENCE_HELM_CHART_NAME;
+        assertThat("assertCoherenceService assert release name", listSvcs.get(0), is(sReleaseName));
+        }
+
+    /**
+     * Return a Coherence Pod selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence Pod selector
+     */
+    protected static String getCoherenceSelector(String sRelease)
+        {
+        return getSelector("coherence", sRelease);
+        }
+
+    /**
+     * Return a Coherence Pod selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence Pod selector
+     */
+    protected static String getCoherencePodSelector(String sRelease)
+        {
+        return getSelector("coherencePod", sRelease);
+        }
+
+    /**
+     * Return a Coherence JMX Pod selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence JMX Pod selector
+     */
+    protected static String getCoherenceJmxPodSelector(String sRelease)
+        {
+        return getSelector("coherenceJMXPod", sRelease);
+        }
+
+    /**
+     * Return a Coherence JMX Deployment selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence JMX Deployment selector
+     */
+    protected static String getCoherenceJmxDeploymentSelector(String sRelease)
+        {
+        return getSelector("coherence-jmx", sRelease);
+        }
+
+    /**
+     * Return a Coherence Service selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence Service selector
+     */
+    protected static String getCoherenceServiceSelector(String sRelease)
+        {
+        return getSelector("coherence-service", sRelease);
+        }
+
+    /**
+     * Return a Coherence Operator selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Coherence Operator selector
+     */
+    protected static String getCoherenceOperatorSelector(String sRelease)
+        {
+        return getSelector("coherence-operator", sRelease);
+        }
+
+    /**
+     * Return a Kibana selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a Kibana selector
+     */
+    protected static String getKibanaSelector(String sRelease)
+        {
+        return getSelector("kibana", sRelease);
+        }
+
+
+    /**
+     * Return a ElasticSearch selector.
+     *
+     * @param sRelease  release name
+     *
+     * @return  a ElasticSearch selector
+     */
+    protected static String getElasticSearchSelector(String sRelease)
+        {
+        return getSelector("elasticsearch", sRelease);
+        }
+
+    /**
+     * Return a selector with the given app name and release name.
+     *
+     * @param sComp     component name
+     * @param sRelease  release name
+     * @return  the selector with the given app name and release name
+     */
+    protected static String getSelector(String sComp, String sRelease)
+        {
+        return "component=" + sComp + ",release=" + sRelease;
+        }
+
+    /**
+     * Determine whether the Helm deployment is ready (i.e all Pods are ready).
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace being used
+     * @param sSelector   the selector
+     *
+     * @return  {@code true} if the deployment is ready
+     */
+    @SuppressWarnings("unchecked")
+    // must be public - used in Eventually.assertThat call.
+    public boolean isDeploymentReady(K8sCluster cluster, String sNamespace, String sSelector)
+        {
+        Map<String, ?> map = getJson(cluster, sNamespace, sSelector, "deployment", false);
+
+        if (map == null)
+            {
+            return false;
+            }
+
+        Map<String, ?> mapSpec    = (Map<String, ?>) map.get("spec");
+        Number         cReplicas  = mapSpec   == null ? null : (Number) mapSpec.get("replicas");
+        Map<String, ?> mapStatus  = (Map<String, ?>) map.get("status");
+        Number         cAvailable = mapStatus == null ? null : (Number) mapStatus.get("availableReplicas");
+
+        return cAvailable != null && cReplicas != null && cAvailable.intValue() == cReplicas.intValue();
+        }
+
+    /**
+     * Assert whether the Helm stateful set is ready or not (i.e all Pods are ready).
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace being used
+     * @param sSelector   the selector
+     * @param fReady      readiness of the statefulset
+     *
+     * @throws AssertionError  if the stateful set is not ready
+     */
+    static void assertStatefulSetReady(K8sCluster cluster, String sNamespace, String sSelector, boolean fReady)
+        {
+        Eventually.assertThat(invoking(STUB).isStatefulSetReady(cluster, sNamespace, sSelector), is(fReady),
+                Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));
+        }
+
+    /**
+     * Determine whether the Helm stateful set is ready (i.e all Pods are ready).
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace being used
+     * @param sSelector   the selector
+     *
+     * @return  {@code true} if the deployment is ready
+     */
+    @SuppressWarnings("unchecked")
+    // must be public - used in Eventually.assertThat call.
+    public boolean isStatefulSetReady(K8sCluster cluster, String sNamespace, String sSelector)
+        {
+        Map<String, ?> map = getJson(cluster, sNamespace, sSelector, "statefulset", false);
+
+        if (map == null)
+            {
+            return false;
+            }
+
+        Map<String, ?> mapSpec    = (Map<String, ?>) map.get("spec");
+        Number         cReplicas  = mapSpec   == null ? null : (Number) mapSpec.get("replicas");
+        Map<String, ?> mapStatus  = (Map<String, ?>) map.get("status");
+        Number         cReady     = mapStatus == null ? null : (Number) mapStatus.get("readyReplicas");
+
+        return cReady != null && cReplicas != null && cReady.intValue() == cReplicas.intValue();
+        }
+
+    /**
+     * Determine whether the coherence start up log is ready.
+     *
+     * param cluster      the k8s cluster
+     * @param sNamespace  the namespace of coherence
+     * @param sPod        the pod name of coherence
+     *
+     * @return  {@code true} if the Logstash is ready
+     */
+    // must be public - used in Eventually.assertThat call.
+    public boolean hasDefaultCacheServerStarted(K8sCluster cluster, String sNamespace, String sPod)
+        {
+        try
+            {
+            Queue<String> sLogs = getPodLog(cluster, sNamespace, sPod);
+            return sLogs.stream().anyMatch(l -> l.contains("Started DefaultCacheServer"));
+            }
+        catch (Exception ex)
+            {
+            return false;
+            }
+        }
+
+    /**
+     * Determine whether the Helm deployment is ready (i.e all Pods are ready).
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace being used
+     * @param sSelector   the selector
+     * @param fLogException  only log exception if true. can fail if deployment or statefulset is not deployed yet.
+     *
+     * @return  {@code true} if the deployment is ready
+     */
+    @SuppressWarnings("unchecked")
+    protected Map<String, ?> getJson(K8sCluster cluster, String sNamespace, String sSelector, String sType, boolean fLogException)
+        {
+        CapturingApplicationConsole console   = new CapturingApplicationConsole();
+        Arguments                   arguments = Arguments.of("get", sType, "--selector", sSelector, "-o", "json");
+
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        int nExitCode = cluster.kubectlAndWait(arguments, LaunchLogging.disabled(), Console.of(console));
+
+        if (nExitCode == 0)
+            {
+            try
+                {
+                String               sJson     = console.getCapturedOutputLines().stream().collect(Collectors.joining());
+                Map<String, ?>       map       = HelmUtils.JSON_MAPPER.readValue(sJson, Map.class);
+                List<Map<String, ?>> listItems = (List<Map<String, ?>>) map.get("items");
+
+                if (listItems != null && listItems.size() > 0)
+                    {
+                    return listItems.get(0);
+                    }
+                }
+            catch (IOException e)
+                {
+                if (fLogException)
+                    {
+                    System.err.println(getClass().getSimpleName() + "is" + sType + "Ready() failed: " + e.getMessage());
+                    }
+                }
+            }
+
+        return null;
+        }
+
+    /**
+     * Obtain the yaml to use to install a client.
+     *
+     * @param name          the client name
+     * @param sRelease      the Helm release name
+     * @param sClusterName  the cluster name
+     *
+     * @return the yaml to use
+     *
+     * @throws IOException if there is an error creating the template
+     */
+    protected String getClientYaml(String name, String sRelease, String sClusterName) throws IOException
+        {
+        final Map<String, String> templateParams = new HashMap<>();
+
+        templateParams.put("%%TEST_REGISTRY_PREFIX%%", System.getProperty("test.image.prefix"));
+        templateParams.put("%%NAME%%", name);
+        templateParams.put("%%NAMESPACE%%", getK8sNamespace());
+        templateParams.put("%%WKA%%", sRelease + "-coherence-headless");
+        templateParams.put("%%LISTEN_PORT%%", "20000");
+        templateParams.put("%%CLUSTER%%", sClusterName);
+        templateParams.put("%%IMAGE_PULL_POLICY%%", (OP_IMAGE_PULL_POLICY == null) ? "IfNotPresent" : OP_IMAGE_PULL_POLICY);
+        templateParams.put("%%IMAGE_PULL_SECRETS%%", K8S_IMAGE_PULL_SECRET);
+
+        String clientTemplateFile = Resources.findFileOrResource("coh-client-template.yaml", null).getPath();
+        String clientYamlContents = IOUtils.toString(new FileInputStream(clientTemplateFile), "UTF-8");
+
+        for (Map.Entry<String, String> entry : templateParams.entrySet())
+            {
+            String sValue = entry.getValue();
+
+            if (sValue == null)
+                {
+                sValue = "";
+                }
+
+            clientYamlContents = clientYamlContents.replaceAll(entry.getKey(), sValue);
+            }
+
+        File clientYaml = new File(clientTemplateFile.substring(0, clientTemplateFile.lastIndexOf("/")), name);
+
+        FileUtils.writeStringToFile(clientYaml, clientYamlContents, "UTF-8");
+
+        return clientYaml.getPath();
+        }
+
+    /**
+     * Remove all k8s resources for the Helm releases.
+     *
+     * @param asRelease  the Helm releases to delete
+     */
+    public static void cleanupHelmReleases(String... asRelease)
+        {
+        int nAttempt = 1;
+        int nMax     = 10;
+
+        if (asRelease != null)
+            {
+            for (String sRelease : asRelease)
+                {
+                int nExitCode = s_helm.delete(sRelease)
+                                      .purge()
+                                      .executeAndWait(Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));
+
+                if (nExitCode == 0)
+                    {
+                    break;
+                    }
+
+                if (nAttempt >= nMax)
+                    {
+                    System.err.println("Maximum number of attempts reached trying to run helm delete for " + sRelease);
+                    }
+
+                System.err.println("Clean-up: (attempt " + nAttempt + ") non-zero return from Helm delete for release "
+                                           + sRelease + " [" + nExitCode + "]");
+                nAttempt++;
+                }
+            }
+        }
+
+    /**
+     * Delete prometheus-operator CRDs.
+     *
+     * @param cluster  the k8s cluster
+     */
+    public static void cleanupPrometheusOperatorCRDs(K8sCluster cluster)
+        {
+        // Prometheus operator is a subchart of coherence-operator.
+        /*
+         * See Uninstalling the Chart on link: https://github.com/helm/charts/tree/master/stable/prometheus-operator
+         *
+         * CRDs created by this chart are not removed by default and should be manually cleaned up:
+         *
+         * kubectl delete crd prometheus.monitoring.coreos.com
+         * kubectl delete crd prometheusrules.monitoring.coreos.com
+         * kubectl delete crd servicemonitors.monitoring.coreos.com
+         * kubectl delete crd alertmanagers.monitoring.coreos.com
+         */
+        for (String sCRD : PROMETHEUS_OPERATOR_CRDS)
+            {
+            deleteCRD(cluster, sCRD);
+            }
+        }
+
+    /**
+     * Delete CRD.
+     *
+     * @param cluster  the k8s cluster
+     * @param sName    CRD name
+     */
+    public static void deleteCRD( K8sCluster cluster, String sName)
+        {
+        int nExitCode = cluster.kubectlAndWait(Arguments.of("delete", "crd", "--ignore-not-found=true", sName));
+
+        if (nExitCode != 0)
+            {
+            // not an error but print out so can catch an unneeded deleteCRD in functional-test.
+            System.err.println("kubectl returned non-zero exit deleting crd named " + sName);
+            }
+        }
+
+    public static void cleanupPrometheusOperator(K8sCluster cluster)
+        {
+        cleanupPrometheusOperatorCRDs(cluster);
+        }
+
+    /**
+     * Capture the Pod logs for the specified release in the current namespace.
+     *
+     * @param clsTest     the test class
+     * @param cluster     the K8s cluster
+     * @param sSelector   the selector
+     */
+    static void capturePodLogs(Class<?> clsTest, K8sCluster cluster, String sSelector)
+        {
+        capturePodLogs(clsTest, cluster, getK8sNamespace(), sSelector, new String[0]);
+        }
+
+    /**
+     * Capture the Pod logs for the specified release in the current namespace.
+     *
+     * @param clsTest     the test class
+     * @param cluster     the K8s cluster
+     * @param sSelector   the selector
+     * @param sContainer  the container
+     */
+    static void capturePodLogs(Class<?> clsTest, K8sCluster cluster, String sSelector, String sContainer)
+        {
+        capturePodLogs(clsTest, cluster, getK8sNamespace(), sSelector, sContainer);
+        }
+
+    /**
+     * Capture the Pod logs for the specified release.
+     *
+     * @param clsTest     the test class
+     * @param cluster     the K8s cluster
+     * @param sNamespace  the k8s namespace
+     * @param sSelector   the selector
+     * @param asContainer the container to capture logs for
+     */
+    static void capturePodLogs(Class<?> clsTest, K8sCluster cluster, String sNamespace, String sSelector, String... asContainer)
+        {
+        try
+            {
+            List<String> listPods = getPods(cluster, sNamespace, sSelector);
+
+            for (String sPod : listPods)
+                {
+                capturePodLog(clsTest, cluster, sNamespace, sPod, asContainer);
+                }
+            }
+        catch (Throwable t)
+            {
+            System.err.println("Error capturing Pod logs");
+            t.printStackTrace();
+            }
+        }
+
+    /**
+     * Capture the Pod logs for the specified release and Pod.
+     *
+     * @param clsTest     the test class
+     * @param cluster     the K8s cluster
+     * @param sNamespace  the k8s namespace
+     * @param sPod        the pod
+     * @param asContainer the container to capture logs for
+     */
+    static void capturePodLog(Class<?> clsTest, K8sCluster cluster, String sNamespace, String sPod, String... asContainer)
+        {
+        if (asContainer == null || asContainer.length == 0)
+            {
+            asContainer = new String[]{null};
+            }
+
+        for (String sContainer : asContainer)
+            {
+            try
+                {
+                File   fileOut   = s_testLogs.getOutputFolder();
+                File   fileRoot  = new File(new File(fileOut, "k8slogs"), clsTest.getSimpleName());
+                fileRoot.mkdirs();
+
+                String                       sLogName  = sPod + (sContainer == null ? "" : "-" + sContainer);
+                File                         fileLog   = new File(fileRoot, sLogName + ".log");
+                FileWriterApplicationConsole console   = new FileWriterApplicationConsole(fileLog.getCanonicalPath());
+
+                Arguments arguments = Arguments.empty();
+
+                if (sNamespace != null)
+                    {
+                    arguments = arguments.with("--namespace", sNamespace);
+                    }
+
+                arguments = arguments.with("logs", sPod);
+
+                if (sContainer != null)
+                    {
+                    arguments = arguments.with(sContainer);
+                    }
+
+                int nExitCode = cluster.kubectlAndWait(arguments, Console.of(console));
+
+                if (nExitCode != 0)
+                    {
+                    System.err.println("kubectl returned non-zero exit code capturing logs for Pod " + sPod);
+                    }
+                }
+            catch (Exception e)
+                {
+                System.err.println("Error capturing Pod logs for Pod " + sPod + " container " + sContainer);
+                e.printStackTrace();
+                }
+            }
+        }
+
+    protected static Queue<String> getPodLog(K8sCluster cluster, String sNamespace, String sPod)
+        {
+        CapturingApplicationConsole console   = new CapturingApplicationConsole();
+
+        Arguments arguments = Arguments.empty();
+
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        arguments = arguments.with("logs", sPod);
+
+        int nExitCode = cluster.kubectlAndWait(arguments, Console.of(console), LaunchLogging.disabled());
+
+        if (nExitCode != 0)
+            {
+                throw new IllegalStateException("kubectl returned non-zero exit code capturing logs for Pod " + sPod);
+            }
+
+        return console.getCapturedOutputLines();
+        }
+
+    protected static Queue<String> getPodLog(K8sCluster cluster, String sNamespace, String sPod, String sContainer)
+        {
+        CapturingApplicationConsole console = new CapturingApplicationConsole();
+
+        getPodLog(cluster, sNamespace, sPod, sContainer, console);
+
+        return console.getCapturedOutputLines();
+        }
+
+    private static void getPodLog(K8sCluster         cluster,
+                                  String             sNamespace,
+                                  String             sPod,
+                                  String             sContainer,
+                                  ApplicationConsole console)
+        {
+        Arguments arguments = Arguments.empty();
+
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        arguments = arguments.with("logs", sPod);
+
+        if (sContainer != null)
+            {
+            arguments = arguments.with("-c", sContainer);
+            }
+
+        cluster.kubectlAndWait(arguments, Console.of(console), LaunchLogging.disabled());
+        }
+
+    protected static void dumpPodLog(K8sCluster cluster, String sNamespace, String sPod)
+        {
+        dumpPodLog(cluster, sNamespace, sPod, null);
+        }
+
+    protected static void dumpPodLog(K8sCluster cluster, String sNamespace, String sPod, String sContainer)
+        {
+        Arguments arguments = Arguments.empty();
+
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        arguments = arguments.with("logs", sPod);
+
+        if (sContainer != null)
+            {
+            arguments = arguments.with("-c", sContainer);
+            }
+
+        System.err.println("-----------------------------------------------------------");
+        System.err.println("Logs for Pod " + sPod + " container " + sContainer);
+        System.err.println("-----------------------------------------------------------");
+        cluster.kubectlAndWait(arguments, SystemApplicationConsole.builder(), LaunchLogging.disabled());
+        System.err.println("-----------------------------------------------------------");
+        }
+
+    /**
+     * Obtain the {@link URL} of the specified resource.
+     *
+     * @param sResource  the name of the resource to locate
+     *
+     * @return  the {@link URL} of the resource
+     */
+    static URL toURL(String sResource)
+        {
+        return Resources.findFileOrResource(sResource, null);
+        }
+
+    /**
+     * Obtain the {@link URL} of the specified URL this.
+     *
+     * @param sUrl  the String to covert to URL
+     *
+     * @return  the {@link URL} of the resource
+     */
+    static URL getURL(String sUrl)
+        {
+        try
+            {
+            return new URL(sUrl);
+            }
+        catch (MalformedURLException e)
+            {
+            return null;
+            }
+        }
+
+    /**
+     * Obtain the default {@link K8sCluster} based
+     * on the System properties passed to the test.
+     *
+     * @return  the default {@link K8sCluster}.
+     */
+    protected static K8sCluster getDefaultCluster()
+        {
+        // try the property first to get the configuration file
+        String sConfig     = getK8sConfig();
+        File   fileConfig  = sConfig == null ? null : new File(sConfig);
+        File   fileKubectl = KUBECTL == null ? null : new File(KUBECTL);
+
+        return new K8sCluster()
+                .withKubectlAt(fileKubectl)
+                .withKubectlConfig(fileConfig)
+                .withKubectlContext(getPropertyOrNull("k8s.context"))
+                .withKubectlInsecure(true);
+        }
+
+    /**
+     * Ensure that the namespace exists, creating it if the {@link #CREATE_NAMESPACE}
+     * flag is {@code true}.
+     *
+     * @param cluster  the k8s cluster
+     *
+     * @throws  AssertionError if the namespace does not exist and {@link #CREATE_NAMESPACE} is false
+     */
+    protected static void ensureNamespace(K8sCluster cluster)
+        {
+        String sNamespace = getK8sNamespace();
+
+        if (sNamespace != null && sNamespace.length() > 0)
+            {
+            ensureNamespace(cluster, sNamespace);
+            }
+        }
+
+    /**
+     * Ensure that the namespace exists, creating it if the {@link #CREATE_NAMESPACE}
+     * flag is {@code true}.
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the name of the namespace
+     *
+     * @throws  AssertionError if the namespace does not exist and {@link #CREATE_NAMESPACE} is false
+     */
+    static void ensureNamespace(K8sCluster cluster, String sNamespace)
+        {
+        System.err.println("Ensuring existence of namespace " + sNamespace + " - create flag is " + CREATE_NAMESPACE);
+
+        boolean fExists = STUB.hasNamespace(cluster, sNamespace);
+
+        if (!fExists)
+            {
+            if (CREATE_NAMESPACE)
+                {
+                // namespace does not exist, try creating it
+                System.err.println("Creating namespace " + sNamespace);
+
+                int nExitCode = cluster.kubectlAndWait(Arguments.of("create", "namespace", sNamespace));
+
+                assertThat("Could not create namespace " + sNamespace, nExitCode, is(0));
+                }
+            else
+                {
+                throw new AssertionError("Namespace " + sNamespace
+                                         + " does not exist and create namespace flag is false");
+                }
+            }
+        else
+            {
+            System.err.println("Namespace " + sNamespace + " already exists.");
+            }
+        }
+
+    /**
+     * If the k8s namespace was created as part of the test then delete it.
+     *
+     * @param cluster the k8s cluster
+     */
+    protected static void cleanupNamespace(K8sCluster cluster)
+        {
+        if (CREATE_NAMESPACE)
+            {
+            String sNamespace = getK8sNamespace();
+
+            if (sNamespace != null && sNamespace.length() > 0)
+                {
+                cleanupNamespace(cluster, sNamespace);
+                }
+            }
+        }
+
+    /**
+     * If the k8s namespace was created as part of the test then delete it.
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the name of the namespace
+     */
+    protected static void cleanupNamespace(K8sCluster cluster, String sNamespace)
+        {
+        if (CREATE_NAMESPACE)
+            {
+            Arguments arguments = Arguments.of("delete", "namespace", sNamespace);
+
+            cluster.kubectlAndWait(arguments);
+
+            Timeout timeout = Eventually.within(5, TimeUnit.MINUTES);
+            Eventually.assertThat(invoking(STUB).hasNamespace(cluster, sNamespace), is(false), timeout, RetryFrequency.every(12, TimeUnit.SECONDS));
+            }
+        }
+
+    /**
+     * Determine whether the specified namespace exists.
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the name of the namespace
+     *
+     * @return  {@code true} if the namespace exists
+     */
+    public boolean hasNamespace(K8sCluster cluster, String sNamespace)
+        {
+        CapturingApplicationConsole console   = new CapturingApplicationConsole();
+        Arguments                   arguments = Arguments.of("get", "namespace");
+        int                         nExitCode = cluster.kubectlAndWait(arguments,
+                                                                       Console.of(console),
+                                                                       LaunchLogging.disabled());
+
+        if (nExitCode == 0)
+            {
+            return console.getCapturedOutputLines().stream()
+                          .anyMatch(line -> line.startsWith(sNamespace + " "));
+            }
+
+        return false;
+        }
+
+    /**
+     * Return true iff all of the {@link #PROMETHEUS_OPERATOR_CRDS Prometheus Operator Custom Resource Definition} (CRD) exist.
+     * If partial number of Prometheus Operator CRD installed, delete all of the remaining ones and return false.
+     *
+     * @param cluster  the k8s cluster
+     *
+     * @return  {@code true} iff all of the Prometheus Operator CRDs are installed
+     */
+    public boolean hasPrometheusOperatorCRD(K8sCluster cluster)
+        {
+        CapturingApplicationConsole console   = new CapturingApplicationConsole();
+        Arguments                   arguments = Arguments.of("get", "crd");
+        int                         nExitCode = cluster.kubectlAndWait(arguments,
+                                                                       Console.of(console),
+                                                                       LaunchLogging.enabled());
+        if (nExitCode == 0)
+            {
+            int nCRDMatches = 0;
+            for (String CRD : PROMETHEUS_OPERATOR_CRDS)
+                {
+                for (String line: console.getCapturedOutputLines())
+                    {
+                    if (line.contains(CRD))
+                        {
+                        nCRDMatches++;
+                        break;
+                        }
+                    }
+                }
+
+            if (nCRDMatches == PROMETHEUS_OPERATOR_CRDS.length)
+                {
+                // all PROMETHEUS_OPERATOR CRDs are installed.
+                return true;
+                }
+            else if (nCRDMatches == 0)
+                {
+                return false;
+                }
+            else
+                {
+                // some CRDs installed, some missing.
+                // delete remaining ones and return false.
+                cleanupPrometheusOperatorCRDs(cluster);
+                return false;
+                }
+            }
+
+        return false;
+        }
+
+    static void cleanupPersistentVolumeClaims(K8sCluster cluster, String sRelease, String sNamespace)
+        {
+        CapturingApplicationConsole console   = new CapturingApplicationConsole();
+        String                      sCluster  = sRelease + "-coherence";
+        Arguments                   arguments = Arguments.of("get", "pvc", "-o", "name", "--selector",
+                                                             "coherenceDeployment=" + sCluster, "--namespace", sNamespace);
+        int                         nExitCode = cluster.kubectlAndWait(arguments,
+                                                                       Console.of(console),
+                                                                       LaunchLogging.enabled());
+
+        if (nExitCode == 0)
+            {
+            console.getCapturedOutputLines().stream()
+                    .filter(s -> !"(terminated)".equals(s))
+                    .forEach(s -> deleteResource(cluster, s, sNamespace));
+            }
+        }
+
+    /**
+     * Delete the specified resource.
+     *
+     * @param cluster    the k8s cluster
+     * @param sName      the name of the resource in the format resource-type/name
+     * @param sNamespace the namespace
+     */
+    protected static void deleteResource(K8sCluster cluster, String sName, String sNamespace)
+        {
+        cluster.kubectlAndWait(Arguments.of("delete", sName, "--namespace", sNamespace));
+        }
+
+    /**
+     * Obtain the name of the K8s configuration file to use.
+     *
+     * @return  the name of the K8s configuration to use
+     */
+    static String getK8sConfig()
+        {
+        // try the property first to get the configuration file
+        String sConfig = getPropertyOrNull("k8s.config");
+
+        if (sConfig == null || sConfig.trim().length() == 0)
+            {
+            // no property so try the env variable to get the configuration file
+            sConfig = System.getenv("KUBECONFIG");
+            }
+
+        if (sConfig == null || sConfig.trim().length() == 0)
+            {
+            // no property so try the env variable to get the configuration file
+            String sFileName = System.getProperty("user.home") + File.separator + ".kube/config";
+            File   file      = new File(sFileName);
+
+            if (file.exists() && file.isFile())
+                {
+                sConfig = sFileName;
+                }
+            }
+
+        return sConfig == null || sConfig.trim().length() == 0 ? null : sConfig;
+        }
+
+    /**
+     * Obtain the k8s namespace to use for tests.
+     *
+     * @return  the k8s namespace to use for tests
+     */
+    protected static String getK8sNamespace()
+        {
+        String sNamespace = getPropertyOrNull("k8s.namespace");
+
+        if (sNamespace == null)
+            {
+            sNamespace = System.getenv("K8S_NAMESPACE");
+            }
+
+        if (sNamespace == null || sNamespace.trim().length() == 0)
+            {
+            sNamespace = System.getenv("CI_BUILD_ID");
+            }
+
+        return sNamespace == null || sNamespace.trim().length() == 0 ? "default" : sNamespace.trim();
+        }
+
+    /**
+     * Obtain the Coherence Chart Repository to use for the test.
+     *
+     * @return the Coherence Chart Repository to use for the test
+     */
+    protected static String getCoherenceCharRepository()
+        {
+        String sChartRepository = getPropertyOrNull("k8s.coherence.chart.repo");
+
+        if (sChartRepository == null)
+            {
+            sChartRepository = System.getenv("K8S_COHERENCE_CHART_REPO");
+            }
+        return sChartRepository == null || sChartRepository.trim().length() == 0 ?
+               DEFAULT_COHERENCE_CHART_REPO : sChartRepository.trim();
+        }
+
+    /**
+     * Obtain the chart versions to test. This is a comma delimited list of versions
+     *
+     * @return the chart versions to test
+     */
+    protected static String[] getChartTestVersions()
+        {
+        // chart versions to
+        String asChartTestVersions = getPropertyOrNull("k8s.chart.test.versions");
+        if (asChartTestVersions == null)
+            {
+            asChartTestVersions = System.getenv("K8S_CHART_TEST_VERSIONS");
+            }
+        if (asChartTestVersions == null)
+            {
+            return EMPTY_TEST_VERSIONS;
+            }
+        String[] sVersions = asChartTestVersions.split(",");
+        return sVersions == null || sVersions.length == 0 ? EMPTY_TEST_VERSIONS : sVersions;
+        }
+
+    /**
+     * Obtain the namespaces for coherence.
+     *
+     * @return an array of target namespaces
+     */
+    protected static String[] getTargetNamespaces()
+        {
+        String sNamespaces = getPropertyOrNull("k8s.target.namespaces");
+
+        if (sNamespaces == null)
+            {
+            sNamespaces = System.getenv("K8S_TARGET_NAMESPACES");
+            }
+
+        if (sNamespaces == null || sNamespaces.trim().length() == 0)
+            {
+            String sCINamespace = System.getenv("CI_BUILD_ID");
+            if (sCINamespace != null)
+                {
+                sNamespaces = sCINamespace + "," + sCINamespace + "2";
+                }
+            }
+
+        return sNamespaces == null || sNamespaces.trim().length() == 0 ? new String[] { null } : sNamespaces.trim().split("\\s*,\\s*");
+        }
+
+    /**
+     * Obtain the default Helm set values.
+     *
+     * @return an array of helm set values
+     */
+    static String[] getDefaultHelmSetValues()
+        {
+        return (OP_IMAGE_PULL_POLICY == null) ? new String[0] :
+            new String[] { "coherenceOperator.imagePullPolicy=" + OP_IMAGE_PULL_POLICY,
+                           "coherence.imagePullPolicy=" + OP_IMAGE_PULL_POLICY,
+                           "coherenceUtils.imagePullPolicy=" + OP_IMAGE_PULL_POLICY,
+                           "userArtifacts.imagePullPolicy=" + OP_IMAGE_PULL_POLICY };
+        }
+
+    /**
+     * Obtain the default Helm set values combined with additional set values.
+     *
+     * @param asSetValues  additional set values
+     *
+     * @return string array containing default and additional specified Helm set values
+     */
+    static String[] withDefaultHelmSetValues(String... asSetValues)
+        {
+        final Predicate<String> isNotBlank = s -> s != null && !s.trim().isEmpty();
+
+        return Stream.concat(Arrays.stream(getDefaultHelmSetValues()), Arrays.stream(asSetValues))
+            .filter(isNotBlank).toArray(String[]::new);
+        }
+
+    /**
+     * Ensure that the k8s image pull secrets exist, creating it if
+     * the {@link #CREATE_SECRET} flag is {@code true}.
+     *
+     * @param cluster      the k8s cluster
+     *
+     * @throws  AssertionError if the secret does not exist and
+     *                         {@link #CREATE_SECRET} is {@code false}
+     */
+    protected static void ensureSecret(K8sCluster cluster)
+        {
+        ensureSecret(cluster, getK8sNamespace());
+        }
+
+    /**
+     * Ensure that the k8s image pull secrets exist, creating it if
+     * the {@link #CREATE_SECRET} flag is {@code true}.
+     *
+     * @param cluster      the k8s cluster
+     * @param sNamespace   the k8s namespace
+     *
+     * @throws  AssertionError if the secret does not exist and
+     *                         {@link #CREATE_SECRET} is {@code false}
+     */
+    static void ensureSecret(K8sCluster cluster, String sNamespace)
+        {
+        String sSecretName = getPropertyOrNull(PROP_K8S_PULL_SECRET);
+
+        ensureSecret(cluster, sNamespace, sSecretName);
+        }
+
+    /**
+     * Ensure that the k8s image pull secrets exist, creating it if
+     * the {@link #CREATE_SECRET} flag is {@code true}.
+     *
+     * @param cluster      the k8s cluster
+     * @param sNamespace   the k8s namespace
+     * @param sSecretName  the name of the secret
+     *
+     * @throws  AssertionError if the secret does not exist and
+     *                         {@link #CREATE_SECRET} is {@code false}
+     */
+    static void ensureSecret(K8sCluster cluster, String sNamespace, String sSecretName)
+        {
+        if (sSecretName == null || sSecretName.length() == 0)
+            {
+            return;
+            }
+
+        Arguments arguments = Arguments.empty();
+
+        if (sNamespace != null && sNamespace.length() > 0)
+            {
+            arguments = arguments.with("--namespace=" + sNamespace);
+            }
+
+        arguments = arguments.with("get", "secret", sSecretName);
+
+        int nExitCode = cluster.kubectlAndWait(arguments);
+
+        if (nExitCode != 0 && CREATE_SECRET)
+            {
+            System.err.println("Creating secret " + sSecretName + " in namespace " + sNamespace);
+
+            String    sRepo     = getPropertyOrDefault(PROP_DOCKER_REPO, "");
+            String    sToken    = getPropertyOrNull(PROP_SECRET_CREDENTIALS);
+            String    sUsername = getPropertyOrDefault(PROP_SECRET_USER, "moreply");
+            String    sEmail    = getPropertyOrDefault(PROP_SECRET_EMAIL, "noreply@oracle.com");
+
+            arguments = Arguments.of("create",
+                                     "secret",
+                                     "docker-registry",
+                                     sSecretName,
+                                     "--docker-server=" + sRepo,
+                                     "--docker-password=" + sToken);
+
+            if (sUsername != null && sUsername.length() > 0)
+                {
+                arguments = arguments.with("--docker-username=" + sUsername);
+                }
+
+            if (sEmail != null && sEmail.length() > 0)
+                {
+                arguments = arguments.with("--docker-email=" + sEmail);
+                }
+
+            if (sNamespace != null && sNamespace.length() > 0)
+                {
+                arguments = arguments.with("--namespace=" + sNamespace);
+                }
+
+            assertThat(cluster.kubectlAndWait(arguments), is(0));
+            }
+        }
+
+    /**
+     * Remove the image pull secrets if the {@link #CREATE_SECRET} flag is {@code true}.
+     *
+     * @param cluster     the k8s cluster
+     */
+    protected static void cleanupPullSecrets(K8sCluster cluster)
+        {
+        cleanupPullSecrets(cluster, getK8sNamespace());
+        }
+
+    /**
+     * Remove the image pull secrets if the {@link #CREATE_SECRET} flag is {@code true}.
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  the k8s namespace
+     */
+    static void cleanupPullSecrets(K8sCluster cluster, String sNamespace)
+        {
+        if (CREATE_SECRET)
+            {
+            String sSecretName = getPropertyOrNull(PROP_K8S_PULL_SECRET);
+
+            if (sSecretName != null && sSecretName.length() > 0)
+                {
+                Arguments arguments = Arguments.empty();
+
+                if (sNamespace != null && sNamespace.length() > 0)
+                    {
+                    arguments = arguments.with("--namespace=" + sNamespace);
+                    }
+
+                arguments = arguments.with("delete", "secret", sSecretName);
+
+                cluster.kubectlAndWait(arguments);
+                }
+            }
+        }
+
+    /**
+     * Install coherence with given helm values and target namespace.
+     *
+     * @param cluster       the k8s cluster
+     * @param urlCoherenceChart URL for Coherence chart
+     * @param sNamespace    the namespace to install into
+     * @param sHelmValues   Helm values file
+     *
+     * @return the name of the Helm release
+     *
+     * @throws Exception if installation fails
+     */
+    protected static String installCoherence(K8sCluster cluster,
+                                      URL        urlCoherenceChart,
+                                      String     sNamespace,
+                                      String     sHelmValues) throws Exception
+        {
+        String[] asReleases = installCoherence(cluster, urlCoherenceChart, new String[]{sNamespace}, sHelmValues);
+        return asReleases[0];
+        }
+
+    /**
+     * Install coherence with given helm values and target namespace.
+     *
+     * @param cluster      the k8s cluster
+     * @param urlCoherenceChart URL for Coherence chart
+     * @param sNamespace   the namespace to install into
+     * @param sHelmValues  the Helm values file
+     * @param asSetValues  the array of Helm set values
+     *
+     * @return the name of the Helm release
+     *
+     * @throws Exception if installation fails
+     */
+    protected static String installCoherence(K8sCluster cluster,
+                                      URL        urlCoherenceChart,
+                                      String     sNamespace,
+                                      String     sHelmValues,
+                                      String...  asSetValues) throws Exception
+        {
+        String[] asReleases = installCoherence(cluster, urlCoherenceChart, new String[]{sNamespace}, sHelmValues, asSetValues);
+        return asReleases[0];
+        }
+
+    /**
+     * Install coherence with given helm values and target namespaces.
+     *
+     * @param cluster           the k8s cluster
+     * @param urlCoherenceChart URL for Coherence chart
+     * @param asCohNamespaces   an array of namespace for installing coherence
+     * @param sHelmValues       Helm values file
+     *
+     * @return an array of release names
+     */
+    protected static String[] installCoherence(K8sCluster cluster,
+                                        URL        urlCoherenceChart,
+                                        String[]   asCohNamespaces,
+                                        String     sHelmValues) throws Exception
+        {
+        return installCoherence(cluster, urlCoherenceChart, asCohNamespaces, sHelmValues, new String[0]);
+        }
+
+    /**
+     * Install coherence with given helm values and target namespaces.
+     *
+     * @param cluster          the k8s cluster
+     * @param urlCoherenceChart URL for Coherence chart            
+     * @param asCohNamespaces  an array of namespace for installing coherence
+     * @param sHelmValues      Helm values file
+     * @param asSetValues      the array of Helm set values
+     *
+     * @return an array of release names
+     */
+    protected static String[] installCoherence(K8sCluster cluster,
+                                        URL        urlCoherenceChart,
+                                        String[]   asCohNamespaces,
+                                        String     sHelmValues,
+                                        String...  asSetValues) throws Exception
+        {
+        String[] asReleases = new String[asCohNamespaces.length];
+
+        for (int i = 0; i < asReleases.length; i++)
+            {
+            String sNamespace = asCohNamespaces[i];
+
+            try
+                {
+                String[] asActualSetValues;
+
+                if (asSetValues == null || asSetValues.length == 0)
+                    {
+                    asActualSetValues = getDefaultHelmSetValues();
+                    }
+                else
+                    {
+                    asActualSetValues = Stream.concat(Arrays.stream(getDefaultHelmSetValues()), Arrays.stream(asSetValues))
+                                              .toArray(String[]::new);
+                    }
+
+                asReleases[i] = installChart(cluster, COHERENCE_HELM_CHART_NAME, urlCoherenceChart, sNamespace, sHelmValues, asActualSetValues);
+                }
+            catch(Throwable throwable)
+                {
+                System.err.println("Install Coherence in namespace " + sNamespace + " failed.");
+                // clean up previous installed Coherence
+                for (String sReleaseName : asReleases)
+                    {
+                    if (sReleaseName != null)
+                        {
+                        try
+                            {
+                            System.err.println("Clean up Helm Coherence install '" + sReleaseName);
+                            cleanupHelmReleases(sReleaseName);
+                            cleanupPersistentVolumeClaims(cluster, sReleaseName, sNamespace);
+                            }
+                        catch (Throwable t)
+                            {
+                            System.err.println("Error in clean up Helm release '" + sReleaseName + "': " + t);
+                            }
+                        }
+                    }
+
+                if (throwable instanceof Exception)
+                    {
+                    throw (Exception) throwable;
+                    }
+                else
+                    {
+                    throw new Exception(throwable);
+                    }
+                }
+            }
+
+        return asReleases;
+        }
+
+    /**
+     * Assert that the Coherence JMX Deployment is up.
+     *
+     * @param cluster     the k8s cluster
+     * @param sNamespace  namespace for installing coherence
+     * @param sRelease    the Helm release name
+     */
+    protected void assertCoherenceJMX(K8sCluster cluster, String sNamespace, String sRelease)
+        throws Exception
+        {
+        String selector = getCoherenceJmxDeploymentSelector(sRelease);
+        assertDeploymentReady(cluster, sNamespace, selector, true);
+
+        ensureJMXServerPartOfCluster(cluster, sNamespace, sRelease);
+        }
+
+    protected void ensureJMXServerPartOfCluster(K8sCluster k8sCluster, String sNamespace, String sRelease)
+        throws Exception
+        {
+        try
+            {
+            Eventually.assertThat("Unable to confirm JMX server is part of cluster",
+                invoking(this).getClusterSizeViaJMX(k8sCluster, sNamespace, sRelease), greaterThanOrEqualTo(2));
+            }
+        catch (Throwable t)
+            {
+            String sCoherenceJmxSelector = getCoherenceJmxPodSelector(sRelease);
+            List<String> listJmxPods = getPods(k8sCluster, sNamespace, sCoherenceJmxSelector);
+            if (listJmxPods.size() > 0)
+                {
+                dumpPodLog(k8sCluster, sNamespace, listJmxPods.get(0));
+                }
+            throw t;
+            }
+        }
+
+    /**
+     * Assert that coherence is up with given helm values, target namespaces and persistence.
+     *
+     * @param cluster        the k8s cluster
+     * @param sCohNamespace  namespace for installing coherence
+     * @param sRelease       the Helm release name
+     */
+    protected static void assertCoherence(K8sCluster cluster, String sCohNamespace, String sRelease)
+        {
+        assertCoherence(cluster, new String[] { sCohNamespace }, new String[] { sRelease });
+        }
+
+    /**
+     * Assert that coherence is up with given helm values, target namespaces and persistence.
+     *
+     * @param cluster          the k8s cluster
+     * @param asCohNamespaces  an array of namespace for installing coherence
+     * @param asReleases       an array of Helm release names
+     */
+    protected static void assertCoherence(K8sCluster cluster, String[] asCohNamespaces, String[] asReleases)
+        {
+        assertThat("Some of Helm installation are failed", asReleases.length, is(asCohNamespaces.length));
+        for (int i = 0; i < asCohNamespaces.length; i++)
+            {
+            String sNamespace = asCohNamespaces[i];
+            String sRelease   = asReleases[i];
+            String sSelector  = getCoherenceSelector(sRelease);
+
+            assertStatefulSetReady(cluster, sNamespace, sSelector, true);
+            }
+        }
+
+    /**
+     * Delete given Coherence for target namespace.
+     *
+     * @param cluster        the k8s cluster
+     * @param sCohNamespace  the coherence target namespace
+     * @param sRelease       the release name of coherence
+     * @param fPersistence   indicates whether coherence cache data is persisted
+     */
+    protected void deleteCoherence(K8sCluster cluster, String sCohNamespace, String sRelease, boolean fPersistence)
+        {
+        deleteCoherence(getClass(), cluster, new String[] { sCohNamespace }, new String[] { sRelease }, fPersistence);
+        }
+
+    /**
+     * Delete given Coherence for target namespace.
+     *
+     * @param cluster        the k8s cluster
+     * @param sCohNamespace  the coherence target namespace
+     * @param sRelease       the release name of coherence
+     * @param fPersistence   indicates whether coherence cache data is persisted
+     */
+    protected static void deleteCoherence(Class clsTest, K8sCluster cluster, String sCohNamespace, String sRelease, boolean fPersistence)
+        {
+        deleteCoherence(clsTest, cluster, new String[] { sCohNamespace }, new String[] { sRelease }, fPersistence);
+        }
+
+    /**
+     * Delete given Coherence for target namespace.
+     *
+     * @param cluster          the k8s cluster
+     * @param asCohNamespaces  an array of coherence target namespaces
+     * @param asReleases        an array of the release names of coherence
+     * @param fPersistence     indicates whether coherence cache data is persisted
+     */
+    protected void deleteCoherence(K8sCluster cluster, String[] asCohNamespaces, String[] asReleases, boolean fPersistence)
+        {
+        deleteCoherence(getClass(), cluster, asCohNamespaces, asReleases, fPersistence);
+        }
+
+    /**
+     * Delete given Coherence for target namespace.
+     *
+     * @param cluster          the k8s cluster
+     * @param asCohNamespaces  an array of coherence target namespaces
+     * @param asReleases        an array of the release names of coherence
+     * @param fPersistence     indicates whether coherence cache data is persisted
+     */
+    protected static void deleteCoherence(Class clsTest, K8sCluster cluster, String[] asCohNamespaces, String[] asReleases, boolean fPersistence)
+        {
+        for (int i = 0; i < asReleases.length; i++)
+            {
+            String sRelease   = asReleases[i];
+            String sNamespace = asCohNamespaces[i];
+            String sSelector  = getCoherencePodSelector(sRelease);
+            capturePodLogs(clsTest, cluster, getK8sNamespace(), sSelector, "coherence", "user-artifacts", "coherence-k8s-utils");
+            cleanupHelmReleases(sRelease);
+            cleanupPersistentVolumeClaims(cluster, sRelease, sNamespace);
+
+            try
+                {
+                assertStatefulSetReady(cluster, sNamespace, getCoherenceSelector(sRelease), false);
+                }
+            catch(Throwable t)
+                {
+                System.err.println("Fail to wait for deleting Coherence release '" + sRelease + "'.");
+                }
+            }
+        }
+
+    /**
+     * Retrieve http result as a queue of String
+     *
+     * @param cluster      the k8s cluster
+     * @param sPod         the pod name
+     * @param sHttpMethod  the http method name
+     * @param sHost        the http host
+     * @param nPort        the http port
+     * @param sPath        the http path
+     *
+     * @return http result as a queue of String
+     */
+    protected Queue<String> processHttpRequest(K8sCluster cluster, String sPod, String sHttpMethod, String sHost, int nPort, String sPath)
+        {
+        // Workaround intermittent kubectl exec returning non-zero due to a communication failure by retrying
+        final int          MAX_RETRY     = 5;
+        AssertionException lastException = null;
+
+        for (int i=0; i < MAX_RETRY; i++)
+            {
+            try
+                {
+                return processHttpRequest(cluster, sPod, sHttpMethod, sHost, nPort, sPath, /*fConsole*/ true);
+                }
+            catch (AssertionException e)
+                {
+                lastException = e;
+                try
+                    {
+                    // backoff before retry
+                    Thread.sleep(500);
+                    }
+                catch (InterruptedException e1)
+                    {
+                    }
+                }
+            }
+        throw lastException;
+        }
+
+    /**
+     * Retrieve http result as a queue of String by executing curl in specified sPod
+     *
+     * @param cluster      the k8s cluster
+     * @param sPod         the pod name to execute curl request in
+     * @param sHttpMethod  the http method name
+     * @param sHost        the http host
+     * @param nPort        the http port
+     * @param sPath        the http path
+     * @param fConsole     if false, do not print result to console.  (for large results needing post processing)
+     *
+     * @return http result as a queue of String
+     */
+    protected Queue<String> processHttpRequest(K8sCluster cluster, String sPod, String sHttpMethod, String sHost, int nPort, String sPath, boolean fConsole)
+        {
+        CapturingApplicationConsole console = new CapturingApplicationConsole();
+
+        Arguments arguments = Arguments.of("exec", "-i", sPod);
+
+        String sNamespace = getK8sNamespace();
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        arguments = arguments.with("--", "curl", "-X", sHttpMethod, sHost + ":" + nPort + sPath);
+
+        int nExitCode = cluster.kubectlAndWait(arguments, LaunchLogging.disabled(), Console.of(console));
+
+        if (fConsole)
+            {
+            HelmUtils.logConsoleOutput("exec-i-http", console);
+            }
+
+        assertThat("kubectl returned non-zero exit code", nExitCode, is(0));
+
+        return console.getCapturedOutputLines();
+        }
+
+    /**
+     * Retrieve http result as a queue of String by executing curl in a temporary pod created to run curl in k8 environment.
+     *
+     * @param cluster      the k8s cluster
+     * @param sHttpMethod  the http method name
+     * @param sHost        the http host
+     * @param nPort        the http port
+     * @param sPath        the http path
+     * @param fConsole     if false, do not print result to console.  (for large results needing post processing)
+     *
+     * @return http result as a queue of String
+     */
+    protected Queue<String> processHttpRequest(K8sCluster cluster, String sHttpMethod, String sHost, int nPort, String sPath, boolean fConsole)
+        {
+        String                      sNamespace = getK8sNamespace();
+        CapturingApplicationConsole console    = new CapturingApplicationConsole();
+
+        Arguments arguments = Arguments.of("run", "--generator=run-pod/v1", "--namespace=" + sNamespace, "--image=library/oraclelinux:7.6", "--restart=Never", "--rm", "-it", "curl");
+
+        arguments = arguments.with("--", "curl", "-X", sHttpMethod, sHost + ":" + nPort + sPath);
+
+        int nExitCode = cluster.kubectlAndWait(arguments, LaunchLogging.disabled(), Console.of(console));
+
+        if (nExitCode != 0)
+            {
+            // recover from failure pod/curl already exists.
+            deleteResource(cluster, "pod/curl", sNamespace);
+            }
+
+        if (fConsole)
+            {
+            HelmUtils.logConsoleOutput("curl-http-request", console);
+            }
+
+        return console.getCapturedOutputLines();
+        }
+
+    /**
+     * Obtain the value of the System property or {@code null}
+     * if the property is not set or is set to empty String.
+     *
+     * @param sPropertyName  the name of the property
+     *
+     * @return  the value of the property or {@code null} if the
+     *          property is not set or is an empty String.
+     */
+    private static String getPropertyOrNull(String sPropertyName)
+        {
+        String sValue = System.getProperty(sPropertyName);
+
+        return sValue == null || sValue.trim().length() == 0 ? null : sValue;
+        }
+
+    /**
+     * Obtain the value of the System property or the default
+     * if the property is not set or is set to empty String.
+     *
+     * @param sPropertyName  the name of the property
+     * @param sDefault       the default value
+     *
+     * @return  the value of the property or the default if the
+     *          property is not set or is an empty String.
+     */
+    private static String getPropertyOrDefault(String sPropertyName, String sDefault)
+        {
+        String sValue = System.getProperty(sPropertyName);
+
+        return sValue == null || sValue.trim().length() == 0 ? sDefault : sValue;
+        }
+
+    /**
+     * Run a kubectl port-forward process to forward a port to a Coherence Pod.
+     *
+     * @param k8sCluster  the {@link K8sCluster} to use
+     * @param sNamespace  the namespace that the Pod is in
+     * @param sRelease    the name of the Helm release that installed the Pod
+     * @param nPort       the Pod's port to forward
+     * @return  an {@link Application} running the port-forward process
+     * @throws Exception  if the port-forward application fails to start
+     */
+    protected static Application portForwardCoherencePod(K8sCluster k8sCluster, String sNamespace, String sRelease, int nPort) throws Exception
+        {
+        String sSelector = getCoherencePodSelector(sRelease);
+        return portForward(k8sCluster, sNamespace, sSelector, nPort);
+        }
+
+    /**
+     * Run a kubectl port-forward process to forward a port to a Pod.
+     *
+     * @param k8sCluster  the {@link K8sCluster} to use
+     * @param sNamespace  the namespace that the Pod is in
+     * @param sSelector   the name of the k8s selector to use to locate a Pod
+     * @param nPort       the Pod's port to forward
+     * @return  an {@link Application} running the port-forward process
+     * @throws Exception  if the port-forward application fails to start
+     */
+    protected static Application internalPortForward(K8sCluster k8sCluster, String sNamespace, String sSelector, int nPort) throws Exception
+        {
+        List<String>                               listPod        = getPods(k8sCluster, sNamespace, sSelector);
+        String                                     sPod           = listPod.get(0);
+        EventsApplicationConsole.CountDownListener listener       = new EventsApplicationConsole.CountDownListener(1);
+        Predicate<String>                          predicate      = s -> s.contains("Forwarding from 127.0.0.1");
+        TestLogs.ConsoleBuilder                    consoleBuilder = s_testLogs.builder();
+
+        // Add a listener to the log that will be triggered when it sees the proxy start message
+        consoleBuilder.clearListeners();
+        consoleBuilder.addStdOutListener(predicate, listener);
+        consoleBuilder.addStdErrListener(predicate, listener);
+
+        Application application = HelmUtils.portForward(k8sCluster, sPod, sNamespace, nPort, consoleBuilder);
+
+        assertThat("Failed to see port forward start message",
+                   listener.await(1, TimeUnit.MINUTES), is(true));
+
+        return application;
+        }
+
+    /**
+     * Run a kubectl port-forward process to forward a port to a Pod.
+     *
+     * @param k8sCluster  the {@link K8sCluster} to use
+     * @param sNamespace  the namespace that the Pod is in
+     * @param sSelector   the name of the k8s selector to use to locate a Pod
+     * @param nPort       the Pod's port to forward
+     *
+     * @return  an {@link Application} running the port-forward process
+     *
+     * @throws Exception  if the port-forward application fails to start
+     */
+    protected static Application portForward(K8sCluster k8sCluster, String sNamespace, String sSelector, int nPort) throws Exception
+        {
+        // Workaround intermittent kubectl port-forward failure by retrying
+        Exception lastException = null;
+        final int MAX_RETRY     = 8;
+        for (int i = 0; i < MAX_RETRY; i++)
+            {
+            try
+                {
+                return internalPortForward(k8sCluster, sNamespace, sSelector, nPort);
+                }
+            catch (Exception e)
+                {
+                lastException = e;
+                try
+                    {
+                    // backoff before retry
+                    Thread.sleep(500);
+                    }
+                catch (InterruptedException e1)
+                    {
+                    }
+                }
+            }
+        throw lastException;
+        }
+
+    /**
+     * Perform a JMX query using JMXMP transport.
+     * <p>
+     * This method will run a kubectl port-forward process to expose the JMX port
+     * then perform the JMX query and close the port-forward process.
+     *
+     * @param k8sCluster    the {@link K8sCluster} to use
+     * @param sNamespace    the namespace that the JMX Pod is in
+     * @param sRelease      the name of the Helm release that installed the JMX Pod
+     * @param objectName    the ObjectName of the MBean to query
+     * @param attributeName the name of the attribute to get
+     * @param <T>           the type of the attribute value
+     *
+     * @return the value of the attribute from the MBean
+     * @throws Exception if the query fails
+     */
+    public <T> T jmxQuery(K8sCluster k8sCluster, String sNamespace, String sRelease, String objectName, String attributeName) throws Exception
+        {
+        String sSelector = getCoherenceJmxPodSelector(sRelease);
+        try (Application application = portForward(k8sCluster, sNamespace, sSelector, 9099))
+            {
+            PortMapping portMapping = application.get(PortMapping.class);
+            int         nPort       = portMapping.getPort().getActualPort();
+
+            return jmxQuery("127.0.0.1", nPort, objectName, attributeName);
+            }
+        }
+
+    /**
+     * Perform a JMX query using JMXMP transport.
+     *
+     * @param hostName      the address that the jmxmp JMX server is bound to
+     * @param port          the port that the jmxmp JMX server is listening on
+     * @param objectName    the ObjectName of the MBean to query
+     * @param attributeName the name of the attribute to get
+     * @param <T>           the type of the attribute value
+     *
+     * @return the value of the attribute from the MBean
+     * @throws Exception if the query fails
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T jmxQuery(String hostName, int port, String objectName, String attributeName) throws Exception
+        {
+        JMXServiceURL jmxURL = new JMXServiceURL("jmxmp", hostName, port);
+
+        try (JMXConnector jmxc = JMXConnectorFactory.connect(jmxURL, null))
+            {
+            MBeanServerConnection serverConnection = jmxc.getMBeanServerConnection();
+
+            return (T) serverConnection.getAttribute(new ObjectName(objectName), attributeName);
+            }
+        }
+
+    /**
+     * Invoke a method on a JMX MBean.
+     * <p>
+     * This method will run a kubectl port-forward process to expose the JMX port
+     * then perform the JMX invoke and close the port-forward process.
+     *
+     * @param k8sCluster    the {@link K8sCluster} to use
+     * @param sNamespace    the namespace that the JMX Pod is in
+     * @param sRelease      the name of the Helm release that installed the JMX Pod
+     * @param objectName  the ObjectName of the MBean to invoke operation
+     * @param methodName  the operation to invoke
+     * @param params      an array containing the parameters to be set when
+     *                    the operation is invoked
+     * @param signature   an array containing the signature of the operation,
+     *                    an array of class names in the format returned by
+     *                    {@link Class#getName()}. The class objects will be
+     *                    loaded using the same class loader as the one used
+     *                    for loading the MBean on which the operation was invoked
+     *
+     * @param <T>         the type of the attribute value
+     *
+     * @return the result of the MBean methodName operation
+     * @throws Exception if the query fails
+     */
+    public <T> T jmxInvoke(K8sCluster k8sCluster,
+                          String sNamespace,
+                          String sRelease,
+                          String objectName,
+                          String methodName,
+                          Object[] params,
+                          String[] signature) throws Exception
+        {
+        String sSelector = getCoherenceJmxPodSelector(sRelease);
+        try (Application application = portForward(k8sCluster, sNamespace, sSelector, 9099))
+            {
+            PortMapping portMapping = application.get(PortMapping.class);
+            int         nPort       = portMapping.getPort().getActualPort();
+
+            return jmxInvoke("127.0.0.1", nPort, objectName, methodName, params, signature);
+            }
+        }
+
+    /**
+     * Invoke a method on a JMX MBean.
+     *
+     * @param hostName    the address that the jmxmp JMX server is bound to
+     * @param port        the port that the jmxmp JMX server is listening on
+     * @param objectName  the ObjectName of the MBean to query
+     * @param methodName  the name of the attribute to get
+     * @param params      an array containing the parameters to be set when
+     *                    the operation is invoked
+     * @param signature   an array containing the signature of the operation,
+     *                    an array of class names in the format returned by
+     *                    {@link Class#getName()}. The class objects will be
+     *                    loaded using the same class loader as the one used
+     *                    for loading the MBean on which the operation was invoked
+     *
+     * @param <T>         the type of the invocation result
+     *
+     * @return the value of the attribute from the MBean
+     *
+     * @throws Exception if the query fails
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T jmxInvoke(String hostName, int port, String objectName, String methodName,
+                           Object[] params, String[] signature) throws Exception
+        {
+        JMXServiceURL jmxURL = new JMXServiceURL("jmxmp", hostName, port);
+
+        try (JMXConnector jmxc = JMXConnectorFactory.connect(jmxURL, null))
+            {
+            MBeanServerConnection serverConnection = jmxc.getMBeanServerConnection();
+
+            return (T) serverConnection.invoke(new ObjectName(objectName), methodName, params, signature);
+            }
+        }
+
+    public Integer getClusterSizeViaJMX(K8sCluster k8sCluster, String sNamespace, String sRelease) throws Exception
+        {
+        String sClusterMBean = "Coherence:type=Cluster";
+        String sAttribute = "ClusterSize";
+        return jmxQuery(k8sCluster, sNamespace, sRelease, sClusterMBean, sAttribute);
+        }
+
+    /**
+     * Return true if current Coherence version is greater than or equal to minimal version.
+     *
+     * @param sMinimalVersion  minimal version of current Coherence
+     *
+     * @return true iff current Coherence version is equal to or greater than minimal version.
+     */
+    protected boolean versionCheck(String sMinimalVersion)
+        {
+        return versionCheck(COHERENCE_VERSION, sMinimalVersion);
+        }
+
+    /**
+     * Return true if specified Coherence version is greater than or equal to minimal version.
+     *
+     * @param sVersion         target Coherence version
+     * @param sMinimalVersion  minimal version of target Coherence
+     *
+     * @return true iff target Coherence version is equal to or greater than minimal version.
+     */
+    protected boolean versionCheck(String sVersion, String sMinimalVersion)
+        {
+        return CoherenceVersion.versionCheck(sVersion, sMinimalVersion);
+        }
+
+    // ----- inner class  ---------------------------------------------------
+
+    /**
+     * The class provides a stub class for com.oracle.bedrock.deferred.DeferredHelper.invoking.
+     */
+    private static class StubHelmChartTest extends BaseHelmChartTest
+        {
+        }
+
+    // ----- data members ---------------------------------------------------
+
+    /**
+     * Release name Regex.
+     */
+    protected final String RELEASE_NAME_REGEX = "%%RELEASE_NAME%%";
+
+    /**
+     * User artifacts Regex.
+     */
+    protected final String USER_ARTIFACTS_IMAGE_REGEX = "%%USER_ARTIFACTS_IMAGE%%";
+
+    /**
+     * Empty list of test versions.
+     */
+    private static final String[] EMPTY_TEST_VERSIONS = new String[0];
+
+    /**
+     * Default Coherence chart repository.
+     */
+    private static final String DEFAULT_COHERENCE_CHART_REPO = "https://oracle.github.io/coherence-operator/charts";
+
+    /**
+     * The default name for the Coherence Operator Helm chart to test.
+     */
+    public static final String DEFAULT_OPERATOR_HELM_CHART = "coherence-operator";
+
+    /**
+     * The default name for the Coherence Helm chart to test.
+     */
+    public static final String DEFAULT_COHERENCE_HELM_CHART = "coherence";
+
+    /**
+     * The System property to use to set the name of the Helm package to test.
+     */
+    public static final String PROP_OPERATOR_HELM_PACKAGE = "operator.helm.chart.package";
+
+    /**
+     * The System property to use to set the name of the Helm package to test.
+     */
+    public static final String PROP_COHERENCE_HELM_PACKAGE = "coherence.helm.chart.package";
+
+    /**
+     * The System property to use to set the name of the Operator Helm chart to test.
+     */
+    public static final String PROP_OPERATOR_HELM_CHART = "operator.helm.chart.name";
+
+    /**
+     * The System property to use to set the name of the Coherence Helm chart to test.
+     */
+    public static final String PROP_COHERENCE_HELM_CHART = "coherence.helm.chart.name";
+
+    /**
+     * The System property to use to obtain the name of the optional k8s docker-registry secret.
+     */
+    public static final String PROP_K8S_PULL_SECRET = "k8s.image.pull.secret";
+
+    /**
+     * The name of the System property to use to determine whether to create and destroy the k8s test namespace.
+     */
+    public static final String PROP_CREATE_NAMESPACE = "k8s.create.namespace";
+
+    /**
+     * The name of the System property to use to determine whether to create and destroy the k8s pull secret.
+     */
+    public static final String PROP_CREATE_SECRET = "k8s.create.secret";
+
+    /**
+     * The name of the System property to use to determine the location of kubectl.
+     */
+    public static final String PROP_KUBECTL = "k8s.kubectl";
+
+    /**
+     * The name of the System property to use to determine the k8s secret user.
+     */
+    public static final String PROP_SECRET_USER = "k8s.secret.user";
+
+    /**
+     * The name of the System property to use to determine the k8s secret credentials.
+     */
+    public static final String PROP_SECRET_CREDENTIALS = "k8s.secret.credentials";
+
+    /**
+     * The name of the System property to use to determine the k8s secret email.
+     */
+    public static final String PROP_SECRET_EMAIL = "k8s.secret.email";
+
+    /**
+     * The name of the System property to use to determine the docker repo name.
+     */
+    public static final String PROP_DOCKER_REPO = "docker.repo";
+
+    /**
+     * The name of the System property to use to determine the operator image pull policy.
+     */
+    public static final String PROP_OP_IMAGE_PULL_POLICY = "op.image.pull.policy";
+
+    /**
+     * The name of the Operator Helm chart package being tested.
+     */
+    protected static final String OPERATOR_HELM_CHART_PACKAGE = System.getProperty(PROP_OPERATOR_HELM_PACKAGE);
+
+    /**
+     * The name of the Helm chart to test.
+     */
+    protected static final String OPERATOR_HELM_CHART_NAME = getPropertyOrDefault(PROP_OPERATOR_HELM_CHART, DEFAULT_OPERATOR_HELM_CHART);
+
+    /**
+     * The name of the Coherence Helm chart package being tested.
+     */
+    protected static final String COHERENCE_HELM_CHART_PACKAGE = System.getProperty(PROP_COHERENCE_HELM_PACKAGE);
+
+    /**
+     * The name of the Helm chart to test.
+     */
+    protected static final String COHERENCE_HELM_CHART_NAME = getPropertyOrDefault(PROP_COHERENCE_HELM_CHART, DEFAULT_COHERENCE_HELM_CHART);
+
+    /**
+     * The operator image pull policy.
+     */
+    protected static final String OP_IMAGE_PULL_POLICY = getPropertyOrNull(PROP_OP_IMAGE_PULL_POLICY);
+
+    /**
+     * The name of the optional k8s docker-registry secret.
+     */
+    protected static final String K8S_IMAGE_PULL_SECRET = getPropertyOrNull(PROP_K8S_PULL_SECRET);
+
+    /**
+     * Flag indicating whether to create and destroy the test namespace.
+     */
+    public static final boolean CREATE_NAMESPACE = Boolean.getBoolean(PROP_CREATE_NAMESPACE);
+
+    /**
+     * Flag indicating whether to create and destroy the test namespace.
+     */
+    public static final boolean CREATE_SECRET = Boolean.getBoolean(PROP_CREATE_SECRET);
+
+    /**
+     * The location of the kubectl.
+     */
+    public static final String KUBECTL = getPropertyOrNull(PROP_KUBECTL);
+
+    /**
+     * The name of the Coherence container in the Coherence Pod.
+     */
+    public static final String COHERENCE_CONTAINER_NAME = "coherence";
+
+    /**
+     * The component name of Coherence Kubernetes Operator.
+     */
+    public static final String COHERENCE_K8S_OPERATOR = "coherence-operator";
+
+    /**
+     * The parameters value to use in a JMX MBean invocation for a method that takes no parameters.
+     */
+    public static final Object[] NO_JMX_PARAMS = new Object[0];
+
+    /**
+     * The signature value to use in a JMX MBean invocation for a method that takes no parameters.
+     */
+    public static final String[] EMPTY_JMX_SIGNATURE = new String[0];
+
+    /**
+     * The version (tag) for the latest Coherence image version being tested.
+     */
+    public static final String COHERENCE_VERSION = System.getProperty("coherence.docker.version");
+
+    /**
+     * A JUnit class rule to create temporary files and folders.
+     */
+    @ClassRule
+    public static TemporaryFolder s_temp = new TemporaryFolder();
+
+    /**
+     * A JUnit class rule to obtain the current test name.
+     */
+    @Rule
+    public final TestName m_testName = new TestName();
+
+    /**
+     * Customer Resource Definitions (CRDs) created when prometheus-operator is installed.
+     */
+    public static final String[] PROMETHEUS_OPERATOR_CRDS =
+        {
+        "prometheuses.monitoring.coreos.com",
+        "prometheusrules.monitoring.coreos.com",
+        "servicemonitors.monitoring.coreos.com",
+        "alertmanagers.monitoring.coreos.com"
+        };
+
+    /**
+     * The mapper to parse json.
+     */
+    public static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * A Bedrock JUnit rule to configure {@link ApplicationConsole}s for tests.
+     */
+    @ClassRule
+    @Rule
+    public static final TestLogs s_testLogs = new TestLogs();
+
+    /**
+     * The Helm command template.
+     */
+    protected static HelmCommand.Template s_helm = Helm.template()
+                       .home(getPropertyOrNull("helm.home"))
+                       .host(getPropertyOrNull("helm.tiller.host"))
+                       .kubeConfig(getK8sConfig())
+                       .kubeContext(getPropertyOrNull("k8s.context"))
+                       .tillerNamespace(getPropertyOrNull("helm.tiller.namespace"));
+
+    /**
+     * A stub {@link BaseHelmChartTest} to use to call methods via {@link Eventually#assertThat(String, Object, Matcher)}
+     */
+    private static final BaseHelmChartTest STUB = new StubHelmChartTest();
+    }

--- a/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/BaseProxySampleTest.java
+++ b/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/BaseProxySampleTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.examples.testing;
+
+import com.oracle.bedrock.runtime.Application;
+import com.oracle.bedrock.runtime.k8s.K8sCluster;
+import com.oracle.bedrock.testsupport.deferred.Eventually;
+import com.tangosol.net.ConfigurableCacheFactory;
+import com.tangosol.net.ExtensibleConfigurableCacheFactory;
+import com.tangosol.net.NamedCache;
+import org.junit.After;
+import org.junit.BeforeClass;
+
+import java.net.URL;
+
+import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Base test class for Proxy samples.
+ *
+ * @author  tam 2019.05.14
+ */
+public class BaseProxySampleTest
+        extends BaseHelmChartTest
+    {
+
+    // ----- constructors ---------------------------------------------------
+
+    /**
+     * No-args constructor.
+     */
+    public BaseProxySampleTest()
+        {
+        }
+
+    /**
+     * Constructor for Parameterized test
+     *
+     * @param sOperatorChartURL   Operator chart URL
+     * @param sCoherenceChartURL  Coherence chart URL
+     */
+    public BaseProxySampleTest(String sOperatorChartURL, String sCoherenceChartURL)
+        {
+        m_sOperatorChartURL  = sOperatorChartURL;
+        m_sCoherenceChartURL = sCoherenceChartURL;
+        System.err.println("Operator Chart:   " + m_sOperatorChartURL + "\nCoherence Chart: " + m_sCoherenceChartURL);
+        }
+
+    // ----- test lifecycle -------------------------------------------------
+    
+    /**
+     * Ensure Kubernetes cluster and namespaces are setup.
+     *
+     */
+    @BeforeClass
+    public static void setupNamespaceAndOperator()
+        {
+        assertPreconditions(s_k8sCluster);
+        ensureNamespace(s_k8sCluster);
+        ensureSecret(s_k8sCluster);
+
+        String sOpNamespace = getK8sNamespace();
+        for (String sNamespace : getTargetNamespaces())
+            {
+            if (sNamespace != null && !sNamespace.equals(sOpNamespace))
+                {
+                ensureNamespace(s_k8sCluster, sNamespace);
+                }
+            }
+        }
+
+    /**
+     * Cleanup any charts created by test.
+     */
+    @After
+    public void cleanupCharts()
+        {
+        if (m_asReleases != null && m_asReleases.length > 0)
+            {
+            for (int i = 0; i < m_asReleases.length; i++)
+                {
+                deleteCoherence(s_k8sCluster, getK8sNamespace(), m_asReleases[i], false);
+                }
+            }
+
+        if (s_sOperatorRelease != null)
+            {
+            try
+                {
+                capturePodLogs(this.getClass(), s_k8sCluster, getCoherenceOperatorSelector(s_sOperatorRelease),
+                    "coherence-operator", "fluentd");
+                cleanupHelmReleases(s_sOperatorRelease);
+                }
+            catch (Throwable t)
+                {
+                System.err.println("Error in cleaning up Helm Releases: " + s_sOperatorRelease);
+                }
+            }
+
+        cleanupPullSecrets(s_k8sCluster);
+        cleanupNamespace(s_k8sCluster);
+
+        for (String sNamespace : getTargetNamespaces())
+            {
+            cleanupNamespace(s_k8sCluster, sNamespace);
+            }
+        }
+
+    /**
+     * Install the Coherence Operator and return the release name.
+     *
+     * @param sValuesFile  values file for additional chart values
+     * @param urlOperator  URL of Coherence Operator to install
+     *
+     * @return the release name
+     *
+     * @throws Exception
+     */
+    protected String installOperator(String sValuesFile, URL urlOperator)
+            throws Exception
+        {
+        System.err.println("Deploying " + OPERATOR_HELM_CHART_NAME + " with " + sValuesFile);
+
+        String sNamespace = getK8sNamespace();
+        String sRelease   = installChart(s_k8sCluster,
+                                          OPERATOR_HELM_CHART_NAME,
+                                          urlOperator,
+                                          sNamespace,
+                                          sValuesFile,
+                                          getDefaultHelmSetValues());
+
+        assertDeploymentReady(s_k8sCluster, sNamespace, getCoherenceOperatorSelector(sRelease), true);
+
+        return sRelease;
+        }
+
+    // ----- helpers --------------------------------------------------------
+
+    /**
+     * Test a given Proxy connection to a release.
+     *
+     * @param sRelease  release to connect to
+     *
+     * @throws Exception
+     */
+    protected void testProxyConnection(String sRelease) throws Exception
+        {
+        try (Application application = portForwardExtend(sRelease))
+            {
+            PortMapping              portMapping = application.get(PortMapping.class);
+            int                      nPort       = portMapping.getPort().getActualPort();
+            ConfigurableCacheFactory ccf         = getCacheFactory("client-cache-config.xml", nPort);
+
+            Eventually.assertThat(invoking(ccf).ensureCache("test", null), is(notNullValue()));
+
+            NamedCache nc = ccf.ensureCache("test", null);
+            nc.put("key-1", "value-1");
+            assertThat(nc.get("key-1"), is("value-1"));
+            ccf.dispose();
+            }
+        }
+    /**
+     * Indicates if a particular instance of a test should be run. The case
+     * where it does not run is when the OPERATOR_HELM_CHART_URL and
+     * COHERENCE_HELM_CHART_URL are both null.
+     *
+     * @return true if a test should be run
+     */
+    protected boolean testShouldRun()
+        {
+        return m_sCoherenceChartURL != null && m_sCoherenceChartURL.length() > 0 &&
+               m_sOperatorChartURL  != null && m_sOperatorChartURL.length() > 0;
+        }
+
+    /**
+     * Port forward to a Coherence pod.
+     *
+     * @param sCoherenceRelease release name
+     *                          
+     * @return
+     * @throws Exception
+     */
+    protected Application portForwardExtend(String sCoherenceRelease) throws Exception
+        {
+        return portForwardCoherencePod(s_k8sCluster, getK8sNamespace(), sCoherenceRelease, 20000);
+        }
+
+    /**
+     * Returns a {@link ConfigurableCacheFactory} for a given cache config and port
+     * 
+     * @param sCacheConfig  cache config to load
+     * @param nPort         port to connect to (127.0.0.1 is assumed for host)
+     * @return
+     */
+    protected ConfigurableCacheFactory getCacheFactory(String sCacheConfig, int nPort)
+        {
+        System.setProperty("coherence.serializer", "java");
+        System.setProperty("proxy.address", "127.0.0.1");
+        System.setProperty("proxy.port", String.valueOf(nPort));
+
+        ExtensibleConfigurableCacheFactory.Dependencies deps
+                = ExtensibleConfigurableCacheFactory.DependenciesHelper.newInstance(sCacheConfig);
+
+        return new ExtensibleConfigurableCacheFactory(deps);
+        }
+
+
+    // ----- data members ---------------------------------------------------
+
+    /**
+     * Operator chart to run test with.
+     */
+    protected String m_sOperatorChartURL;
+
+    /**
+     * Coherence chart to run test with.
+     */
+    protected String m_sCoherenceChartURL;
+
+    // ----- constants ------------------------------------------------------
+
+    /**
+     * The k8s cluster to use to install the charts.
+     */
+    protected static K8sCluster s_k8sCluster = getDefaultCluster();
+
+    /**
+     * The name of the deployed Operator Helm release.
+     */
+    protected static String s_sOperatorRelease;
+
+    /**
+     * The name of the deployed Coherence Helm releases.
+     */
+    protected String[] m_asReleases;
+    }

--- a/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/HelmUtils.java
+++ b/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/HelmUtils.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.examples.testing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oracle.bedrock.options.LaunchLogging;
+import com.oracle.bedrock.runtime.Application;
+import com.oracle.bedrock.runtime.ApplicationConsoleBuilder;
+import com.oracle.bedrock.runtime.LocalPlatform;
+import com.oracle.bedrock.runtime.console.CapturingApplicationConsole;
+import com.oracle.bedrock.runtime.console.SystemApplicationConsole;
+import com.oracle.bedrock.runtime.k8s.K8sCluster;
+import com.oracle.bedrock.runtime.network.AvailablePortIterator;
+import com.oracle.bedrock.runtime.options.Arguments;
+import com.oracle.bedrock.runtime.options.Console;
+import com.oracle.bedrock.runtime.options.DisplayName;
+import com.oracle.bedrock.util.Capture;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author jk
+ */
+public class HelmUtils
+    {
+    /**
+     * Private constructor for utility method class.
+     */
+    private HelmUtils()
+        {
+        }
+
+    /**
+     * Extract the specified tar.gz file.
+     *
+     * @param fileTarget  the directory to extract to
+     * @param url         the tar.gz to extract
+     *
+     * @throws IOException  if there is an error
+     */
+    public static void extractTarGZ(File fileTarget, URL url) throws IOException
+        {
+        fileTarget.mkdirs();
+
+        try (InputStream in = url.openStream())
+            {
+            int bufferSize                   = 1024 * 1024;
+            GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(in);
+
+            try (TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn))
+                {
+                TarArchiveEntry entry;
+
+                while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null)
+                    {
+                    if (entry.isDirectory())
+                        {
+                        File    file     = new File(fileTarget, entry.getName());
+                        boolean fCreated = file.mkdir();
+
+                        if (!fCreated)
+                            {
+                            throw new IOException("Unable to create directory during extraction of archive contents. " +
+                                                  file.getAbsolutePath());
+                            }
+                        }
+                    else
+                        {
+                        byte data[] = new byte[bufferSize];
+                        int  count;
+
+                        File             file = new File(fileTarget, entry.getName());
+                        FileOutputStream out  = new FileOutputStream(file, false);
+
+                        try (BufferedOutputStream dest = new BufferedOutputStream(out, bufferSize))
+                            {
+                            while ((count = tarIn.read(data, 0, bufferSize)) != -1)
+                                {
+                                dest.write(data, 0, count);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    /**
+     * Dump the specified console output to the logs.
+     *
+     * @param sPrefix  the prefix to add to each line
+     * @param console  the console to dump
+     */
+    public static void logConsoleOutput(String sPrefix, CapturingApplicationConsole console)
+        {
+        logConsoleOutput(sPrefix, console, System.out, System.err);
+        }
+
+    /**
+     * Dump the specified console output to the logs.
+     *
+     * @param sPrefix  the prefix to add to each line
+     * @param console  the console to dump
+     * @param out      the {@link PrintStream} to write to console output to
+     */
+    public static void logConsoleOutput(String sPrefix, CapturingApplicationConsole console, PrintStream out)
+        {
+        logConsoleOutput(sPrefix, console, out, out);
+        }
+
+    /**
+     * Dump the specified console output to the logs.
+     *
+     * @param sPrefix  the prefix to add to each line
+     * @param console  the console to dump
+     * @param out      the {@link PrintStream} to write to console std-out to
+     * @param err      the {@link PrintStream} to write to console std-err to
+     */
+    public static void logConsoleOutput(String                      sPrefix,
+                                        CapturingApplicationConsole console,
+                                        PrintStream                 out,
+                                        PrintStream                 err)
+        {
+        AtomicInteger cOut = new AtomicInteger();
+        AtomicInteger cErr = new AtomicInteger();
+
+        console.getCapturedOutputLines()
+                .forEach(s -> out.printf("[%s:out] %4d: %s\n", sPrefix, cOut.getAndIncrement(), s));
+        out.flush();
+        console.getCapturedErrorLines()
+                .forEach(s -> err.printf("[%s:err] %4d: %s\n", sPrefix, cErr.getAndIncrement(), s));
+        err.flush();
+        }
+
+
+    /**
+     * Remove all k8s resources with the cloudCollectionsTesting=true label.
+     *
+     * @param cluster    the k8s cluster
+     */
+    public static void cleanupTestResources(K8sCluster cluster, String sNamespace)
+        {
+        Arguments args = Arguments.of("delete", "all", "--selector", "cloudCollectionsTesting=true");
+
+        if (sNamespace != null)
+            {
+            args = args.with("--namespace", sNamespace);
+            }
+
+        int nExitCode = cluster.kubectlAndWait(args);
+
+        if (nExitCode != 0)
+            {
+            System.err.println("Clean-up: non-zero return from kubectl [" + nExitCode + "]");
+            }
+        }
+
+    /**
+     * Start a kubectl port-forward process.
+     *
+     * @param cluster    the k8s cluster
+     * @param sSelector  the selector
+     * @param nPort      the port to forward
+     *
+     * @return  the kubectl {@link Application}
+     */
+    public static Application portForward(K8sCluster cluster, String sNamespace, String sSelector, int nPort)
+        {
+        List<String> listPods = getPods(cluster, sNamespace, sSelector);
+        String       sPod     = listPods.get(0);
+
+        return portForward(cluster, sPod, sNamespace, nPort, SystemApplicationConsole.builder());
+        }
+
+    /**
+     * Start a kubectl port-forward process.
+     *
+     * @param cluster         the k8s cluster
+     * @param sPod            the pod name
+     * @param sNamespace      the k8s namespace
+     * @param nPort           the port to forward
+     * @param consoleBuilder  the {@link ApplicationConsoleBuilder}
+     *
+     * @return  the kubectl {@link Application}
+     */
+    public static Application portForward(K8sCluster                cluster,
+                                          String                    sPod,
+                                          String                    sNamespace,
+                                          int                       nPort,
+                                          ApplicationConsoleBuilder consoleBuilder)
+        {
+        AvailablePortIterator ports       = LocalPlatform.get().getAvailablePorts();
+        Capture<Integer>      port        = new Capture<>(ports);
+        PortMapping           portMapping = new PortMapping(String.valueOf(nPort), port, nPort);
+        String                sName       = "kubectl-port-forward[" + nPort + "@" + sPod + "]";
+        Arguments             arguments   = Arguments.of("port-forward", sPod, portMapping);
+
+        if (sNamespace != null)
+            {
+            arguments = arguments.with("--namespace", sNamespace);
+            }
+
+        if (consoleBuilder == null)
+            {
+            consoleBuilder = SystemApplicationConsole.builder();
+            }
+
+        Application application = cluster.kubectl(DisplayName.of(sName), consoleBuilder, arguments);
+
+        application.add(portMapping);
+
+        return application;
+        }
+
+
+    /**
+     * Obtain the list of Pod names for the given Helm release.
+     *
+     * @param cluster     the k8s cluster running the Pods
+     * @param sNamespace  the k8s namespace to use
+     * @param sSelector   the selector
+     *
+     * @return  the {@link List} of Pod names
+     */
+    public static List<String> getPods(K8sCluster cluster, String sNamespace, String sSelector)
+        {
+        return getK8sObject(cluster, "pods", sNamespace, sSelector);
+        }
+
+    /**
+     * Obtain the list k8s object name for the given Helm release.
+     *
+     * @param cluster     the k8s cluster running
+     * @param objectName  the k8s object name
+     * @param sNamespace  the k8s namespace to use
+     * @param sSelector   the selector
+     *
+     * @return  the {@link List} of Pod names
+     */
+    public static List<String> getK8sObject(K8sCluster cluster, String objectName, String sNamespace, String sSelector)
+        {
+        return getK8sObject(cluster, objectName, sNamespace, sSelector, "{.items[*].metadata.name}");
+        }
+
+    /**
+     * Obtain the list k8s object name for the given Helm release.
+     *
+     * @param cluster     the k8s cluster running
+     * @param objectName  the k8s object name
+     * @param sNamespace  the k8s namespace to use
+     * @param sSelector   the selector
+     * @param sJsonPath   the json path
+     *
+     * @return  the {@link List} of Pod names
+     */
+    public static List<String> getK8sObject(K8sCluster cluster, String objectName, String sNamespace, String sSelector, String sJsonPath)
+        {
+        CapturingApplicationConsole console = new CapturingApplicationConsole();
+
+        Arguments                   args    = Arguments.of("get", objectName);
+
+        if (sNamespace != null && sNamespace.trim().length() > 0)
+            {
+            args = args.with("--namespace", sNamespace);
+            }
+
+        args = args.with("-o", "jsonpath=\"" + sJsonPath +"\"", "-l", sSelector);
+
+        int nExitCode = cluster.kubectlAndWait(args, LaunchLogging.disabled(), Console.of(console));
+
+        logConsoleOutput("get-" + objectName + "-jsonpath-" + sJsonPath, console);
+
+        assertThat("kubectl returned non-zero exit code", nExitCode, is(0));
+
+        String sList = console.getCapturedOutputLines().poll();
+
+        // strip any leading quote
+        if (sList.charAt(0) == '"')
+            {
+            sList = sList.substring(1);
+            }
+
+        // strip any trailing quote
+        if (sList.endsWith("\""))
+            {
+            sList = sList.substring(0, sList.length() - 1);
+            }
+
+        List<String> list = new ArrayList<>((sList.trim().length() == 0) ? Collections.emptyList() : Arrays.asList(sList.split(" ")));
+
+        Collections.sort(list);
+
+        return list;
+        }
+
+    // ----- data members ---------------------------------------------------
+
+    /**
+     * The timeout to use for Helm commands, default 300 seconds.
+     */
+    public static final int HELM_TIMEOUT = Integer.parseInt(System.getProperty("helm.timeout", "300"));
+
+    /**
+     *
+     */
+    public static final int K8S_MIN_FORWARD_PORT = Integer.getInteger("k8s.min.forward.port", 40000);
+
+    /**
+     * An {@link ObjectMapper} to convert json to Objects and vice-versa.
+     */
+    public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    }

--- a/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/PortMapping.java
+++ b/docs/samples/testing-support/src/test/java/com/oracle/coherence/examples/testing/PortMapping.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package com.oracle.coherence.examples.testing;
+
+import com.oracle.bedrock.runtime.options.Ports;
+import com.oracle.bedrock.util.Capture;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * @author jk
+ */
+public class PortMapping
+    {
+    // ----- constructors ---------------------------------------------------
+
+    public PortMapping(String sName, int nPortContainer)
+        {
+        this(sName, nPortContainer, nPortContainer);
+        }
+
+    public PortMapping(String sName, int nPortLocal, int nPortContainer)
+        {
+        this(sName, Collections.singleton(nPortLocal).iterator(), nPortContainer);
+        }
+
+    public PortMapping(String sName, Iterator<Integer> itPortLocal, int nPortContainer)
+        {
+        this(sName, new Capture<>(itPortLocal), nPortContainer);
+        }
+
+    public PortMapping(String sName, Capture<Integer> port, int nPortContainer)
+        {
+        m_sName         = sName;
+        m_capture       = port;
+        m_portContainer = nPortContainer;
+        }
+
+    // ----- PortMapping methods ------------------------------------------------
+
+    @Override
+    public String toString()
+        {
+        return m_capture.get() + ":" + m_portContainer;
+        }
+
+    public Ports.Port getPort()
+        {
+        return new Ports.Port(m_sName, m_capture.get(), m_portContainer);
+        }
+
+    // ----- data members ---------------------------------------------------
+
+    private String m_sName;
+
+    private Capture<Integer> m_capture;
+
+    private int m_portContainer;
+    }


### PR DESCRIPTION
modified:   docs/quickstart.md

- I observed that the configmaps are no longer created, so instructing
  the reader to delete them is a mistake.

modified:   docs/samples/README.md

- Improve wording in JDK version advisory.

- Moved `coherence.version` advisory to after the reader checks out the
  `pom.xml` to which it applies.

- Improved wording of reason for creating secrets.

- After discussion with Patrick Fry, changed `coherence.version` to
  12.2.1.3-0, since that is the most recent publically available
  version.

- Used bold for Note.

- Fixed typo.

modified:   docs/samples/operator/logging/log-capture/README.md

- Specify that the dashboards are Kibana dashboards.

modified:   docs/samples/pom.xml

- After discussion with Patrick Fry, changed `coherence.version` to
  12.2.1.3-0, since that is the most recent publically available
  version.
