### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <glassfish.copyright.version>2.1</glassfish.copyright.version>
     <glassfish.jmxmp.version>1.0-b01-ea</glassfish.jmxmp.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <junit.version>4.12</junit.version>
     <javax.activation.version>1.2.0</javax.activation.version>
     <javax.xml.bind.version>2.3.0</javax.xml.bind.version>


### PR DESCRIPTION
security vulnerability in com.fasterxml.jackson.core:jackson-databind >= 2.0.0, < 2.9.9

CVE-2019-12086
More information
moderate severity
Vulnerable versions: >= 2.0.0, < 2.9.9
Patched version: 2.9.9

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.