### PR TITLE
#142 Test that logs can be queried per-member and that they can be ma…

### DIFF
--- a/functional-tests/src/test/resources/values/helm-values-coh-efk-single-member-log-extract.yaml
+++ b/functional-tests/src/test/resources/values/helm-values-coh-efk-single-member-log-extract.yaml
@@ -1,0 +1,18 @@
+# Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+
+clusterSize: 2
+
+cluster: mycluster
+
+role: myrole
+
+store:
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds:       10
+  javaOpts: -Dtest1=dummy
+
+logCaptureEnabled: true
+
+elasticsearchEndpoint:
+  host: elasticsearch.${k8s.namespace}.svc.cluster.local


### PR DESCRIPTION
…de to look like regular Coherence logs.

functional-tests/src/test/java/helm/EFKHelmChartIT.java

- Add testPerMemberLogs().

- Add verifyNoneMatchEFKData() and getPerHostLogMessages().

- Add getPodMetadataValues(), copied from getPodUids(), but modified to
  take metadataKey as an argument.  Add getPodNames() that calls
  getPodMetadataValues() passing "name" as the metadataKey argument.
  Modify getPodUids() to call getPodMetadataValues(), passing "uid" as
  the metadataKey argument.