### PR TITLE
Add node scheduling values to coherence-operator deployment.  (just a…

### DIFF
--- a/operator/src/main/helm/coherence-operator/README.md
+++ b/operator/src/main/helm/coherence-operator/README.md
@@ -57,12 +57,17 @@ chart and their default values.
 | `service.annotations` | Service annotations yaml | |
 | `coherenceOperator.image` | Coherence Operator image to be pulled | `"oracle/coherence-operator:1.0.0-SNAPSHOT"` |
 | `coherenceOperator.imagePullPolicy` | Image pull policy | `"IfNotPresent"` |
+| `affinity` | Affinity that controls Pod scheduling preferences | `{}`|
+| `nodeSelector` | Node lables for pod assignment | `{}` |
+| `tolerations` | For nodes that have taints on them. See (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration) | `[]` |
 | `javaLoggingLevel` | Java logging level | `"INFO"` |
 | `logCaptureEnabled` | Whether log capture via EFK stack is enabled | `false` |
 | `elasticsearch.image` | Elasticsearch Docker image url with tag | `docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0` |
 | `elasticsearch.imagePullPolicy` | Elasticsearch image pull policy | `"IfNotPresent"` |
 | `elasticsearchEndpoint.host` | Elasticsearch host installed separately | `"elasticsearch.${namespace}.svc.cluster.local` |
-| `elasticsearchEndpoint.port` | Elasticsearch port intalled separately | `9200` |
+| `elasticsearchEndpoint.port` | Elasticsearch port installed separately | `9200` |
+| `elasticsearchEndpoint.user` | Elasticsearch login credential for user when installed separately | |
+| `elasticsearchEndpoint.password` | Elasticsearch login credential for password when installed separately | |
 | `logstash.image` | Logstash Docker image url with tag | `docker.elastic.co/logstash/logstash-oss:6.6.0` |
 | `logstash.imagePullPolicy` | Logstash image pull policy | `"IfNotPresent"` |
 | `kibana.image` | Kibana Docker image url with tag | `docker.elastic.co/beats/filebeat:6.2.4` |

--- a/operator/src/main/helm/coherence-operator/templates/deployment.yaml
+++ b/operator/src/main/helm/coherence-operator/templates/deployment.yaml
@@ -39,6 +39,21 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+# ---------------------------------------------------------------------------
+# Node scheduling
+# ---------------------------------------------------------------------------
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
       containers:
 # ---------------------------------------------------------------------------
 #  Container: coherence-operator

--- a/operator/src/main/helm/coherence-operator/values.yaml
+++ b/operator/src/main/helm/coherence-operator/values.yaml
@@ -39,6 +39,29 @@ serviceAccount: default
 imagePullSecrets: []
 
 # ---------------------------------------------------------------------------
+# Pod scheduling values
+
+# affinity controls Pod scheduling preferences.
+#   ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# nodeSelector is the Node labels for pod assignment
+# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+# tolerations is for nodes that have taints on them.
+#   Useful if you want to dedicate nodes to just run the coherence container
+#   For example:
+#   tolerations:
+#   - key: "key"
+#     operator: "Equal"
+#     value: "value"
+#     effect: "NoSchedule"
+#
+#   ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# ---------------------------------------------------------------------------
 # service groups the values used to configure the internal K8s service
 service:
   # name of the service. It must be unique among services.


### PR DESCRIPTION
…s done for coherence helm chart)

Document in coherence-operator README.md elasticseachEndpoint user and password. (they already were in fluentd config in coherence-operator configmap and documented in samples
just not in coherence-operator README.md)