### PR TITLE
update from former default prometheus metrics http port value of 9095…

### DIFF
--- a/docs/prometheusoperator.md
+++ b/docs/prometheusoperator.md
@@ -119,11 +119,11 @@ spec:
       component: "coherence-service"
 ...      
 endpoints:
-  - port: 9095
+  - port: 9612
 ```
 
 If the Coherence helm chart parameter `service.metricsHttpPort` is set when installing the Coherence helm chart,
-replace `9095` above with the new value.
+replace `9612` above with the new value.
 
 If the Coherence helm chart parameter `store.metrics.ssl.enabled` is set to `true`, then add  `endpoints.scheme` with the value of `https`
 to the `coherence-service-monitor.yaml` fragment.

--- a/docs/samples/operator/metrics/own-prometheus/README.md
+++ b/docs/samples/operator/metrics/own-prometheus/README.md
@@ -83,10 +83,10 @@ spec:
       component: "coherence-service"
 ...
 endpoints:
-  - port: 9095
+  - port: 9612
 ```
 
-If the parameter `service.metricsHttpPort` is set when installing the Coherence Helm chart, replace `port: 9095` with the new value.
+If the parameter `service.metricsHttpPort` is set when installing the Coherence Helm chart, replace `port: 9612` with the new value.
   
 If the Coherence Helm chart parameter `store.metrics.ssl.enabled` is `true`, add `endpoints.scheme` value of `https` to `coherence-service-monitor.yaml` fragment.
 

--- a/docs/samples/operator/metrics/ssl/README.md
+++ b/docs/samples/operator/metrics/ssl/README.md
@@ -86,11 +86,11 @@ Ensure you have already installed the Coherence Operator using the instructions 
 1. Start port forward for the metrics port:
 
    ```bash
-   $ kubectl port-forward storage-coherence-0 -n sample-coherence-ns 9095:9095
+   $ kubectl port-forward storage-coherence-0 -n sample-coherence-ns 9612:9612
    ```
    ```console
-   Forwarding from [::1]:9095 -> 9095
-   Forwarding from 127.0.0.1:9095 -> 9095
+   Forwarding from [::1]:9612 -> 9612
+   Forwarding from 127.0.0.1:9612 -> 9612
    ```   
 
 1. (Optional) Configure Prometheus.

--- a/docs/samples/operator/metrics/ssl/src/main/java/com/oracle/coherence/examples/SampleMetricsClient.java
+++ b/docs/samples/operator/metrics/ssl/src/main/java/com/oracle/coherence/examples/SampleMetricsClient.java
@@ -21,7 +21,7 @@ public class SampleMetricsClient
     public static void main(String ... args)
         {
         try {
-            HttpSSLHelper clientHelper = new HttpSSLHelper(9095);
+            HttpSSLHelper clientHelper = new HttpSSLHelper(9612);
             Client clientStarLord = clientHelper.getClient(HttpSSLHelper.CERT_STAR_LORD,
                                                              HttpSSLHelper.STORE_PASSWORD,
                                                              HttpSSLHelper.KEY_PASSWORD,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -955,9 +955,9 @@ To configure a SSL endpoint for Coherence metrics:
 To verify that the Coherence metrics for Prometheus is running with HTTPS, forward the Coherence metrics port and access the metrics from your local machine use the following commands:
 
   ```bash
-  $ kubectl port-forward <Coherence pod> 9095:9095
+  $ kubectl port-forward <Coherence pod> 9612:9612
 
-  $ curl -X GET https://localhost:9095/metrics --cacert <caCert> --cert <certificate>
+  $ curl -X GET https://localhost:9612/metrics --cacert <caCert> --cert <certificate>
   ```
 
 You can add `--insecure` if you use self-signed certificate. Also, look for the following message in the log file of the Coherence pod:</br>
@@ -973,7 +973,7 @@ After configuring Prometheus to use SSL, verify that the Prometheus is scraping 
 
   http://localhost:9090/graph
   ```
-You should see many coherence_* metrics.   
+You should see many vendor:coherence_* metrics.   
 
 To enable SSL for both management over REST and metrics publishing for Prometheus, install the Coherence chart with both YAML files:
 


### PR DESCRIPTION
… to 9612.

update reference to coherence metrics to have prefix of vendor:coherence_.