### PR TITLE
fix intermittent failure with 12.2.1.3.2 in EFKHelmTest#testCoherenceRoleClusterUid

### DIFF
--- a/functional-tests/src/test/java/helm/EFKHelmChartIT.java
+++ b/functional-tests/src/test/java/helm/EFKHelmChartIT.java
@@ -205,15 +205,21 @@ public class EFKHelmChartIT
             assertThat(verifyEFKData(m_asReleases[i], "pod-uid", listUids.get(0)), is(true));
             }
 
+        Eventually.assertThat(invoking(this).isKibanaReady(),
+            is(true),
+            MaximumRetryDelay.of(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
+            RetryFrequency.every(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
+            Eventually.within(HELM_TIMEOUT, TimeUnit.SECONDS));
+
         // validate that the 2 index patterns exists. This ensures that the initContainer to
         // load the kibana-dashboard-data.json has been loaded
+        Eventually.assertThat("Kibana Coherence operator index pattern does not exist",
+            invoking(this).isKibanaIndexPatternReady(COHERENCE_OPERATOR_INDEX_PATTERN), is(true),
+            MaximumRetryDelay.of(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
+            RetryFrequency.every(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
+            Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));
         Eventually.assertThat("Kibana Coherence cluster index pattern does not exist",
                 invoking(this).isKibanaIndexPatternReady(COHERENCE_CLUSTER_INDEX_PATTERN), is(true),
-                MaximumRetryDelay.of(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
-                RetryFrequency.every(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
-                Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));
-        Eventually.assertThat("Kibana Coherence operator index pattern does not exist",
-                invoking(this).isKibanaIndexPatternReady(COHERENCE_OPERATOR_INDEX_PATTERN), is(true),
                 MaximumRetryDelay.of(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
                 RetryFrequency.every(RETRY_FREQUENCEY_SECONDS, TimeUnit.SECONDS),
                 Timeout.after(HELM_TIMEOUT, TimeUnit.SECONDS));


### PR DESCRIPTION
Addresses following intermittent failure:

test-2 / helm.EFKHelmChartIT.testCoherenceRoleClusterUid: Kibana Coherence cluster index pattern does not exist: [DeferredInvoke{boolean.isKibanaIndexPatternReady(6abb1220-3feb-11e9-a9a3-4b1c09db6e6a)}] due to was <false> 

Fix is to ensure kibana ready before checking if index loaded by initcontainer is loaded.
Similar ensure kibana ready check  was added to  helm.EFKHelmChartIT#testApplicationEnabledLogging() recently. 