### PR TITLE
Make both rack and site come from the failure-domain.beta.kubernetes.…

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	DefaultSiteLabel       = "failure-domain.beta.kubernetes.io/zone"
-	DefaultRackLabel       = "failure-domain.beta.kubernetes.io/region"
+	zoneLabel = "failure-domain.beta.kubernetes.io/zone"
+	//	regionLabel            = "failure-domain.beta.kubernetes.io/region"
+	DefaultSiteLabel       = zoneLabel
+	DefaultRackLabel       = zoneLabel
 	DefaultRestHost        = "0.0.0.0"
 	DefaultRestPort  int32 = 8000
 


### PR DESCRIPTION
…io/zone node label