### PR TITLE
doc edit updates

### DIFF
--- a/docs/about/02_concepts.adoc
+++ b/docs/about/02_concepts.adoc
@@ -18,72 +18,52 @@
 
 = Coherence Operator Concepts
 
-== What is the Coherence Operator
-The Coherence Operator is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/[Kubernetes Operator] that
+== What is Coherence Operator?
+Coherence Operator is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/[Kubernetes Operator] that
 is used to manage https://docs.oracle.com/middleware/12213/coherence/[Oracle Coherence] clusters in Kubernetes.
-The Coherence Operator takes on the tasks of that human Dev Ops resource might carry out when managing Coherence clusters,
-such as configuration, installation, safe scaling, management and metrics.
+The Coherence Operator (the "operator") takes a place in the DevOps toolkit when managing Coherence Clusters, such as configuration, installation, safe scaling, management and metrics.
 
 The Coherence Operator is a Go based application built using the https://github.com/operator-framework/operator-sdk[Operator SDK].
 It is distributed as a Docker image and Helm chart for easy installation and configuration.
 
 
 == Coherence Clusters
-Traditionally a Coherence cluster is a number of distributed JVMs that communicate to form a single coherent cluster. 
-In Kubernetes this concept still applies but can now be though of as a number of Pods that form a single cluster. 
-Inside each `Pod` is a JVM running Coherence, or some custom application using Coherence.
+A Coherence Cluster is a number of distributed Java Virtual Machines (JVMs) that communicate to form a single coherent cluster. 
+In Kubernetes, this concept can be related to a number of Pods that form a single cluster. 
+In each Pod, there is a JVM running Coherence or some custom application using Coherence.
 
-The Coherence Operator uses a Kubernetes Custom Resource Definition to represent a Coherence cluster
-(and the roles withing it, see below). Every field in the `CoherenceCluster` crd `Spec` is optional so a cluster
-can be defined by yaml as simple as this:
+The operator uses the Kubernetes Custom Resource Definition (CRD) to represent a Coherence Cluster and the roles within it. Every field in the `CoherenceCluster` CRD `Spec` is optional and a simple cluster can be defined in a `yaml` file as:
 
 [source,yaml]
 ----
 apiVersion: coherence.oracle.com/v1
 kind: CoherenceCluster
 metadata:
-  name: my-cluster  <1>
+  name: my-cluster
 ----
 
-<1> The `metadata.name` field in the `CoherenceCluster` will be used as the Coherence cluster name and would obviously
-be unique in a given k8s namespace.
+Provide a unique cluster name in the `metadata.name` field of the `CoherenceCluster`. The name must be unique in a given Kubernetes namespace.
 
-The Coherence Operator will use default values for fields that have not been entered, so the above yaml will create
-a Coherence cluster made up of a `StatefulSet` with a replica count of 3, so there will be three storage enabled
-Coherence `Pods`.
+The operator uses default values for the fields that have not been entered and the `yaml` creates a `StatefulSet` Coherence Cluster that has three replicas, which means that there are three storage enabled Coherence Pods.
    
 
-
 == Coherence Roles
-A Coherence cluster can be made up of a number of Pods that perform different roles. All of the Pods in a given role
-share the same configuration. At a bare minimum a cluster would have at least one role where Pods are storage enabled.
+A Coherence Cluster can be made up of a number of Pods that perform different roles. All of the Pods in a given role
+share the same configuration. A cluster has at least one role in which Pods are storage enabled.
 
-Each role in a Coherence cluster has a name and configuration. A cluster can have zero or many roles defined in the 
-`CoherenceCluster` crd `Spec`. It is possible to define common configuration shared by all roles to save duplicating
-configuration multiple times in the yaml.
+Each role in a Coherence Cluster has a name and configuration. A cluster can have zero or many roles defined in the 
+`CoherenceCluster` CRD `Spec`. You can define the common configuration shared by all roles in the `yaml` file instead of duplicating the configuration multiple times in the `yaml`.
 
-The Coherence Operator will create a `StatefulSet` for each role defined in the `CoherenceCluster` crd yaml.
+The operator creates a `StatefulSet` for each role defined in the `CoherenceCluster` CRD `yaml`.
 This separation allows roles to be managed and scaled independently from each other.
 
+Even if there are no roles described in the `yaml`, the operator creates a default role with the name
+`storage` and gives a replica count to three. 
 
-As described above the minimal yaml to define a CoherenceCluster is:
-
-[source,yaml]
-----
-apiVersion: coherence.oracle.com/v1
-kind: CoherenceCluster
-metadata:
-  name: my-cluster
-----
-
-Although there are no roles described in this yaml the Coherence Operator will create a default role with the name
-`storage` and give it a replica count of three. 
-
-There are two ways to describe the specification of a role in a `CoherenceCluster` crd depending on whether the cluster
+There are two ways to describe the specification of a role in a `CoherenceCluster` CRD depending on whether the cluster
 created will have a single role or multiple roles.
 
-The same configuration to create a single role three member cluster as the minimal yaml could be specified more fully 
-as follows:
+The `yaml` configuration to create a cluster with single role and three member:
 
 [source,yaml]
 ----
@@ -92,16 +72,15 @@ kind: CoherenceCluster
 metadata:
   name: my-cluster
 spec:
-  role: storage  <1>
-  replicas: 3    <2>
+  role: storage  
+  replicas: 3    
 ----   
 
-<1> The `role` field specifies the name of the role, in this case `stroage`.
-<2> The `replicas` field defines the number of Pods that will be started for this role, in this case three.
+The `role` specifies the name of the role, in this case `storage`.
+The `replicas` defines the number of Pods that are started for this role, in this case three.
 
 
-If a cluster will have multiple roles they are defined in the `spec.roles` list; so again the same cluster could be
-defined more fully as:
+If a cluster must have multiple roles, it is defined in the `spec.roles` list and the `yaml` configuration is as follows:
 
 [source,yaml]
 ----
@@ -110,15 +89,14 @@ kind: CoherenceCluster
 metadata:
   name: my-cluster
 spec:
-  roles:              <1>
+  roles:              
     - role: storage
       replicas: 3
 ----
 
-<1> This time the role is defined in the `roles` section of the yaml. The `roles` section is a list of one or more role
-specifications.
+The `roles` section in the `yaml` defines the list of one or more role specifications.
 
-Multiple roles can be defined by adding more roles with distinct names to the `roles` list; for example:
+You can define multiple roles by adding more roles with distinct names to the `roles` list, for example:
 
 [source,yaml]
 ----
@@ -128,16 +106,10 @@ metadata:
   name: my-cluster
 spec:
   roles:
-    - role: storage   <1>
-      replicas: 3     <2>
-    - role: web       <3>
-      replicas: 2     <4>
+    - role: storage   
+      replicas: 3     
+    - role: web       
+      replicas: 2     
 ----
 
-<1> In this case there are two roles defined, the first names `storage`,
-<2> with three replicas
-<3> and the second named `web`
-<4> with two replicas.
-
-This will result in a Coherence cluster with a total of five members.
-The Coherence Operator would create two `StatefulSets`, one for `storage` with three `Pods` and one for `web` with two `Pods`.
+In the example, there are two roles defined, the first named `storage` with three replicas, and the second named `web` with two replicas. A Coherence Cluster is created with a total of five members. The operator creates two `StatefulSets`, one for `storage` with three Pods and one for `web` with two Pods.

--- a/docs/clusters/010_introduction.adoc
+++ b/docs/clusters/010_introduction.adoc
@@ -22,32 +22,30 @@ Creating a Coherence cluster using the Coherence Operator is as simple as creati
 
 == Create CoherenceCluster Resources
 
-The Coherence Operator uses a Kubernetes `CustomResourceDefinition` named `CoherenceCluster` to define the `spec` for a
-Coherence cluster.
-All of the fields of the `CoherenceCluster` crd are optional so a Coherence cluster can be created with yaml as
-simple as the following:
+The Coherence Operator uses the Kubernetes customer resource (CRD) named `CoherenceCluster` to define the `spec` for a
+Coherence Cluster.
+All the fields in the `CoherenceCluster` CRD are optional and a simple Coherence cluster can be created using `yaml` as
+follows:
 
 [source,yaml]
 ----
 apiVersion: coherence.oracle.com/v1
 kind: CoherenceCluster
 metadata:
-  name: my-cluster  <1>
+  name: my-cluster  
 ----
 
-<1> The `metadata.name` field will be used as the Coherence cluster name.
+The `metadata.name` field defines the cluster name.
 
-The yaml above will create a Coherence cluster with three storage enabled members. 
-There is not much that can actually be achived with this cluster because no ports are exposed outside of Kubernetes
-so the cluster is inaccessible. It could be accessed by other `Pods` in the same
+Using this `yaml` configuration, you can create a Coherence Cluster with three storage enabled members. The cluster created is inaccessible as there are no ports exposed outside of Kubernetes. The cluster is accessible by other `Pods` in the same namespace.
 
 == Coherence Roles
 
-A role is what is actually configured in the `CoherenceCluster` spec. In a traditional Coherence application that may have
-had a number of storage enabled members and a number of storage disable Coherence*Extend proxy members this cluster would
-have effectively had two roles, "storage" and "proxy".
-Some clusters may simply have just a storage role and some complex Coherence applications and clusters may have many roles
-and even different roles storage enabled for different caches/services within the same cluster.
+You can configure the role of a cluster in the `CoherenceCluster` spec. A cluster can have zero to many roles defined in the spec. 
+
+For example, a Coherence application that has a number of storage enabled members and storage disabled Coherence*Extend proxy members, the cluster must have two roles, `storage` and `proxy`.
+
+Some clusters can just have a storage role with some complex Coherence applications while some cluster can have many roles and even different roles of storage enabled for different caches or services within the same cluster.
 
 
 


### PR DESCRIPTION
I have two pages edited:
1. concepts.adoc
2. introduction.adoc

In the introduction.adoc, please have a look at the section Coherence Roles whether the meaning is retained in that section. Also, in the concept.adoc, in Coherence Cluster section, the name of the cluster must be unique in a given <dash>. It is not complete and I have added it as Kuberneted namespace. Is that correct?
