### PR TITLE
Add securityContext to the Operator Helm chart

### DIFF
--- a/docs/installation/01_installation.adoc
+++ b/docs/installation/01_installation.adoc
@@ -159,6 +159,7 @@ helm install  \
 To change the replica count when installing the Operator using Helm, the `replicas` value can be set.
 
 For example, to change the replica count from 3 to 1, the `--set replicas=1` option can be used.
+
 [source,bash]
 ----
 helm install  \
@@ -168,8 +169,45 @@ helm install  \
     coherence/coherence-operator
 ----
 
+=== Run the Operator as a Non-Root User
 
-==== Uninstall the Coherence Operator Helm chart
+The Operator container can be configured with a `securityContext` so that it runs as a non-root user.
+
+This can be done using a values file:
+
+[source,yaml]
+.security-values.yaml
+----
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+----
+
+Then the `security-values.yaml` values file above can be used in the Helm install command.
+
+[source,bash]
+----
+helm install  \
+    --namespace <namespace> \
+    --values security-values.yaml \
+    coherence \
+    coherence/coherence-operator
+----
+
+Alternatively, the `securityContext` values can be set on the command line as `--set` parameters:
+
+[source,bash]
+----
+helm install  \
+    --namespace <namespace> \
+    --set securityContext.runAsNonRoot=true \
+    --set securityContext.runAsUser=1000 \
+    coherence \
+    coherence/coherence-operator
+----
+
+
+=== Uninstall the Coherence Operator Helm chart
 
 To uninstall the operator:
 [source,bash]

--- a/helm-charts/coherence-operator/templates/deployment.yaml
+++ b/helm-charts/coherence-operator/templates/deployment.yaml
@@ -165,6 +165,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
+{{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+{{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/helm-charts/coherence-operator/values.yaml
+++ b/helm-charts/coherence-operator/values.yaml
@@ -43,6 +43,17 @@ replicas: 3
 imagePullSecrets:
 
 # ---------------------------------------------------------------------------
+# Operator container securityContext
+# This sets the securityContext configuration for the container, for example
+# to run as a non-root user:
+#
+#  securityContext:
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#
+securityContext:
+
+# ---------------------------------------------------------------------------
 # Pod scheduling values
 
 # affinity controls Pod scheduling preferences.

--- a/test/e2e/helm/helm_test.go
+++ b/test/e2e/helm/helm_test.go
@@ -98,7 +98,7 @@ func TestSetNonRootUser(t *testing.T) {
 		"--set", "securityContext.runAsUser=1000")
 
 	g.Expect(err).NotTo(HaveOccurred())
-	AssertHelmInstallWithSubTest(t, "basic", cmd, g, AssertResources)
+	AssertHelmInstallWithSubTest(t, "basic", cmd, g, AssertThreeReplicas)
 }
 
 func AssertResources() error {

--- a/test/e2e/helm/helm_test.go
+++ b/test/e2e/helm/helm_test.go
@@ -83,9 +83,20 @@ func TestSetReplicas(t *testing.T) {
 	AssertHelmInstallWithSubTest(t, "basic", cmd, g, AssertSingleReplica)
 }
 
-func TestSetReResources(t *testing.T) {
+func TestSetResources(t *testing.T) {
 	g := NewGomegaWithT(t)
-	cmd, err := createHelmCommand("--set", "replicas=1", "--set", "resources.requests.cpu=250m", "--set", "resources.requests.memory=64Mi", "--set", "resources.limits.cpu=512m", "--set", "resources.limits.memory=128Mi")
+	cmd, err := createHelmCommand("--set", "replicas=1", "--set", "resources.requests.cpu=250m",
+		"--set", "resources.requests.memory=64Mi", "--set", "resources.limits.cpu=512m",
+		"--set", "resources.limits.memory=128Mi")
+	g.Expect(err).NotTo(HaveOccurred())
+	AssertHelmInstallWithSubTest(t, "basic", cmd, g, AssertResources)
+}
+
+func TestSetNonRootUser(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cmd, err := createHelmCommand("--set", "securityContext.runAsNonRoot=true",
+		"--set", "securityContext.runAsUser=1000")
+
 	g.Expect(err).NotTo(HaveOccurred())
 	AssertHelmInstallWithSubTest(t, "basic", cmd, g, AssertResources)
 }


### PR DESCRIPTION
Add the ability to set the Operator container's `securityContext` field when using Helm to install the Operator.