### PR TITLE
Update documentation regarding use of JMXMP

### DIFF
--- a/api/v1/coherence_types.go
+++ b/api/v1/coherence_types.go
@@ -532,6 +532,8 @@ type JVMSpec struct {
 	// +optional
 	Memory *JvmMemorySpec `json:"memory,omitempty"`
 	// Configure JMX using JMXMP.
+	// Note: This should only be used in development as JMXMP does not have support for encrypted connections via TLS.
+	// Use in production should ideally put the JMXMP port behind some sort of TLS enabled ingress or network policy.
 	// +optional
 	Jmxmp *JvmJmxmpSpec `json:"jmxmp,omitempty"`
 	// A flag indicating whether to automatically add the default classpath for images

--- a/docs/jvm/080_jmx.adoc
+++ b/docs/jvm/080_jmx.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, Oracle and/or its affiliates.
+    Copyright (c) 2020, 2023, Oracle and/or its affiliates.
     Licensed under the Universal Permissive License v 1.0 as shown at
     http://oss.oracle.com/licenses/upl.
 
@@ -23,6 +23,15 @@ to port 9099 in the container but this can be configured to bind to a different 
 
 NOTE: Using a custom transport for JMX, such as JMXMP, requires any JMX client that will connect to the JMX server to
 also have a JMXMP library on its classpath.
+
+[WARNING]
+====
+JMXMP does not support secure transports such as TLS so cannot be recommended for production use.
+If used in production clusters, then the JMXMP ports should be secured behind TLS enabled ingress or
+with suitable network policies.
+
+Coherence has other mechanisms to access management APIs and metrics that do support TLS.
+====
 
 See the <<docs/management/030_visualvm.adoc,VisualVM Example>> for a detailed example of how to configure
 JMX and connect to a server in a `Coherence` resource.

--- a/docs/management/030_visualvm.adoc
+++ b/docs/management/030_visualvm.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, Oracle and/or its affiliates.
+    Copyright (c) 2020, 2023, Oracle and/or its affiliates.
     Licensed under the Universal Permissive License v 1.0 as shown at
     http://oss.oracle.com/licenses/upl.
 
@@ -30,6 +30,14 @@ for how to connect to a cluster via the VisualVM plugin using REST.
 NOTE: See the https://docs.oracle.com/en/middleware/standalone/coherence/14.1.1.0/manage/introduction-oracle-coherence-management.html[Coherence Management Documentation]
 for more information on JMX and Management.
 
+[WARNING]
+====
+JMXMP does not support secure transports such as TLS so cannot be recommended for production use.
+If used in production clusters, then the JMXMP ports should be secured behind TLS enabled ingress or
+with suitable network policies.
+
+Coherence has other mechanisms to access management APIs and metrics that do support TLS.
+====
 
 === Prerequisites
 


### PR DESCRIPTION
Update documentation to state that JMXMP should only be used in development, and is not recommended for use in a production cluster