### PR TITLE
Update K8s versions in certification tests

### DIFF
--- a/.github/workflows/k8s-matrix.yaml
+++ b/.github/workflows/k8s-matrix.yaml
@@ -40,45 +40,40 @@ jobs:
       fail-fast: false
       matrix:
         matrixName:
+          - v1.27
           - v1.26
           - v1.25
           - v1.24
           - v1.23
           - v1.22
           - v1.21
-          - v1.20
-          - v1.19
         include:
+          - matrixName: v1.27
+            k8s: kindest/node:v1.27.1@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09
+            kindCommand: kind-calico
+            runNetTests: true
           - matrixName: v1.26
-            k8s: kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+            k8s: kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f
             kindCommand: kind-calico
             runNetTests: true
           - matrixName: v1.25
-            k8s: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+            k8s: kindest/node:v1.25.8@sha256:00d3f5314cc35327706776e95b2f8e504198ce59ac545d0200a89e69fce10b7f
             kindCommand: kind-calico
             runNetTests: true
           - matrixName: v1.24
-            k8s: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+            k8s: kindest/node:v1.24.12@sha256:1e12918b8bc3d4253bc08f640a231bb0d3b2c5a9b28aa3f2ca1aee93e1e8db16
             kindCommand: kind-calico
             runNetTests: true
           - matrixName: v1.23
-            k8s: kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
+            k8s: kindest/node:v1.23.17@sha256:e5fd1d9cd7a9a50939f9c005684df5a6d145e8d695e78463637b79464292e66c
             kindCommand: kind-calico
             runNetTests: true
           - matrixName: v1.22
-            k8s: kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41
+            k8s: kindest/node:v1.22.17@sha256:c8a828709a53c25cbdc0790c8afe12f25538617c7be879083248981945c38693
             kindCommand: kind-calico
             runNetTests: true
           - matrixName: v1.21
-            k8s: kindest/node:v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1
-            kindCommand: kind
-            runNetTests: false
-          - matrixName: v1.20
-            k8s: kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
-            kindCommand: kind
-            runNetTests: false
-          - matrixName: v1.19
-            k8s: kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7
+            k8s: kindest/node:v1.21.14@sha256:27ef72ea623ee879a25fe6f9982690a3e370c68286f4356bf643467c552a3888
             kindCommand: kind
             runNetTests: false
 

--- a/.github/workflows/minikube-matrix.yaml
+++ b/.github/workflows/minikube-matrix.yaml
@@ -40,16 +40,19 @@ jobs:
       fail-fast: false
       matrix:
         matrixName:
-#          - v1.26
+          - v1.27
+          - v1.26
           - v1.25
           - v1.24
         include:
-#          - matrixName: v1.26
-#            k8s: v1.26.1
+          - matrixName: v1.27
+            k8s: v1.27.1
+          - matrixName: v1.26
+            k8s: v1.26.3
           - matrixName: v1.25
-            k8s: 1.25.4
+            k8s: 1.25.8
           - matrixName: v1.24
-            k8s: 1.24.7
+            k8s: 1.24.12
 
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -1619,7 +1619,7 @@ kind-load-compatibility:   ## Load the compatibility test images into the KinD c
 
 # the version of minikube to install
 MINIKUBE_VERSION ?= latest
-MINIKUBE_K8S     ?= 1.25.4
+MINIKUBE_K8S     ?= 1.25.8
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Start Minikube


### PR DESCRIPTION
Update K8s compatibility versions to use:

- v1.27.1
- v1.26.3
- v1.25.8
- v1.24.12
- v1.23.17
- v1.22.17
- v1.21.14 

Update Minikube compatibility tests to use k8s versions:

- v1.27.1
- v1.26.3
- v1.25.8
- v1.24.12

