### PR TITLE
Fix version check to work with interim Coherence releases

### DIFF
--- a/java/coherence-operator/src/main/java/com/oracle/coherence/k8s/CoherenceVersion.java
+++ b/java/coherence-operator/src/main/java/com/oracle/coherence/k8s/CoherenceVersion.java
@@ -18,7 +18,7 @@ import com.tangosol.net.CacheFactory;
  */
 public class CoherenceVersion {
 
-    private static final Pattern PATTERN = Pattern.compile("(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*");
+    private static final Pattern PATTERN = Pattern.compile("(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*(\\d*)\\D*");
 
     /**
      * Private constructor for utility class.
@@ -34,11 +34,13 @@ public class CoherenceVersion {
     public static void main(String[] args) {
         int exitCode = 0;
 
+        String version = System.getenv().getOrDefault("COH_VERSION_CHECK", CacheFactory.VERSION);
+
         if (args != null && args.length > 0) {
-            exitCode = versionCheck(CacheFactory.VERSION, args) ? 0 : 1;
+            exitCode = versionCheck(version, args) ? 0 : 1;
         }
         else {
-            System.out.println(CacheFactory.VERSION);
+            System.out.println(version);
         }
 
         System.exit(exitCode);
@@ -52,11 +54,19 @@ public class CoherenceVersion {
      * @return {@code true} if the actual Coherence version is at least the check version
      */
     public static boolean versionCheck(String coherenceVersion, String... args) {
+        if (coherenceVersion.contains(" ")) {
+            coherenceVersion = coherenceVersion.substring(0, coherenceVersion.indexOf(" "));
+        }
         if (coherenceVersion.contains(":")) {
             coherenceVersion = coherenceVersion.substring(coherenceVersion.indexOf(":") + 1);
         }
 
         int[] coherenceParts = splitVersion(coherenceVersion);
+
+        if (coherenceParts.length == 0) {
+            return false;
+        }
+
         int[] versionParts = splitVersion(args[0]);
         int partCount = Math.min(coherenceParts.length, versionParts.length);
 

--- a/java/coherence-operator/src/main/java/com/oracle/coherence/k8s/CoherenceVersion.java
+++ b/java/coherence-operator/src/main/java/com/oracle/coherence/k8s/CoherenceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */

--- a/java/coherence-operator/src/test/java/com/oracle/coherence/k8s/CoherenceVersionTest.java
+++ b/java/coherence-operator/src/test/java/com/oracle/coherence/k8s/CoherenceVersionTest.java
@@ -50,4 +50,11 @@ public class CoherenceVersionTest {
         assertThat(CoherenceVersion.versionCheck("1.1.1.1.1", "1.1.1.1.2"), is(false));
         assertThat(CoherenceVersion.versionCheck("1.2", "2.1"), is(false));
     }
+
+    @Test
+    public void shouldWorkWithInterimBuild() throws Exception {
+        assertThat(CoherenceVersion.versionCheck("14.1.1.0.15 (101966-Int)", "14.1.1.0.0"), is(true));
+        assertThat(CoherenceVersion.versionCheck("14.1.1.0.15 (101966-Int)", "22.06.0"), is(false));
+    }
+
 }

--- a/java/coherence-operator/src/test/java/com/oracle/coherence/k8s/CoherenceVersionTest.java
+++ b/java/coherence-operator/src/test/java/com/oracle/coherence/k8s/CoherenceVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */


### PR DESCRIPTION
The version check the Operator uses to determine the Coherence version being used fails for interim releases where the version string has the format `14.1.1.0.15 (101966-Int)`.