### PR TITLE
Ensure the rack name configured by the Operator is unique across sites

### DIFF
--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -212,7 +212,7 @@ func (s server) getRackLabelForNode(w http.ResponseWriter, r *http.Request) {
 func (s server) getLabelForNode(labels, prefixLabels []string, w http.ResponseWriter, r *http.Request) {
 	var value string
 	labelUsed := "<None>"
-	prefixUsed := "<None>"
+	var prefixUsed = "<None>"
 
 	path := r.URL.Path
 	// strip off any trailing slash
@@ -233,7 +233,7 @@ func (s server) getLabelForNode(labels, prefixLabels []string, w http.ResponseWr
 			prefixValue := ""
 			for _, label := range prefixLabels {
 				if prefix, ok := node.Labels[label]; ok && prefix != "" {
-					prefixUsed = label
+					labelUsed = label
 					prefixValue = prefix + "-"
 					break
 				}
@@ -264,7 +264,7 @@ func (s server) getLabelForNode(labels, prefixLabels []string, w http.ResponseWr
 	if _, err = fmt.Fprint(w, value); err != nil {
 		log.Error(err, "Error writing value response for node "+name)
 	} else {
-		log.Info("GET query for node labels", "node", name, "label", labelUsed, "value", value, "remoteAddress", r.RemoteAddr)
+		log.Info("GET query for node labels", "node", name, "label", labelUsed, "prefix", prefixUsed, "value", value, "remoteAddress", r.RemoteAddr)
 	}
 }
 

--- a/test/e2e/remote/zone_test.go
+++ b/test/e2e/remote/zone_test.go
@@ -39,7 +39,7 @@ func TestSiteLabel(t *testing.T) {
 		return fmt.Sprintf("zone-zone-test-sts.%s.svc", namespace)
 	}
 
-	assertLabel(t, "zone", "zone-test.yaml", operator.DefaultSiteLabels, fn, dfn)
+	assertLabel(t, "zone", "zone-test.yaml", operator.DefaultSiteLabels, []string{}, fn, dfn)
 }
 
 // Verify that a Coherence resource deployed by the Operator has the correct site value
@@ -58,7 +58,7 @@ func TestCustomSiteLabel(t *testing.T) {
 		return fmt.Sprintf("custom-site-zone-test-sts.%s.svc", namespace)
 	}
 
-	assertLabel(t, "custom-site", "zone-test-custom-site.yaml", []string{"coherence.oracle.com/test"}, fn, dfn)
+	assertLabel(t, "custom-site", "zone-test-custom-site.yaml", []string{"coherence.oracle.com/test"}, operator.DefaultSiteLabels, fn, dfn)
 }
 
 // Verify that a Coherence resource deployed by the Operator has the correct rack value
@@ -77,7 +77,7 @@ func TestRackLabel(t *testing.T) {
 		return "n/a"
 	}
 
-	assertLabel(t, "rack", "zone-test.yaml", operator.DefaultRackLabels, fn, dfn)
+	assertLabel(t, "rack", "zone-test.yaml", operator.DefaultRackLabels, operator.DefaultSiteLabels, fn, dfn)
 }
 
 // Verify that a Coherence resource deployed by the Operator has the correct rack value
@@ -96,10 +96,10 @@ func TestCustomRackLabel(t *testing.T) {
 		return "n/a"
 	}
 
-	assertLabel(t, "custom-rack", "zone-test-custom-rack.yaml", []string{"coherence.oracle.com/test"}, fn, dfn)
+	assertLabel(t, "custom-rack", "zone-test-custom-rack.yaml", []string{"coherence.oracle.com/test"}, []string{}, fn, dfn)
 }
 
-func assertLabel(t *testing.T, name string, fileName string, labels []string, fn func(management.MemberData) string, dfn func(string) string) {
+func assertLabel(t *testing.T, name string, fileName string, labels, prefixLabels []string, fn func(management.MemberData) string, dfn func(string) string) {
 	g := NewGomegaWithT(t)
 	namespace := helper.GetTestNamespace()
 
@@ -145,14 +145,25 @@ func assertLabel(t *testing.T, name string, fileName string, labels []string, fn
 		g.Expect(err).NotTo(HaveOccurred())
 
 		actual := fn(member)
-		expected := ""
 
+		// find the first non-blank prefix label as that is the label that should have been used
+		prefix := ""
+		for _, label := range prefixLabels {
+			labelValue := node.GetLabels()[label]
+			t.Logf("Node %s prefix label '%s' value '%s'", node.Name, label, labelValue)
+			if labelValue != "" {
+				prefix = labelValue + "-"
+				break
+			}
+		}
+
+		expected := ""
 		// find the first non-blank label as that is the label that should have been used
 		for _, label := range labels {
 			labelValue := node.GetLabels()[label]
 			t.Logf("Node %s label '%s' value '%s'", node.Name, label, labelValue)
 			if labelValue != "" {
-				expected = labelValue
+				expected = prefix + labelValue
 				break
 			}
 		}

--- a/test/e2e/remote/zone_test.go
+++ b/test/e2e/remote/zone_test.go
@@ -58,7 +58,7 @@ func TestCustomSiteLabel(t *testing.T) {
 		return fmt.Sprintf("custom-site-zone-test-sts.%s.svc", namespace)
 	}
 
-	assertLabel(t, "custom-site", "zone-test-custom-site.yaml", []string{"coherence.oracle.com/test"}, operator.DefaultSiteLabels, fn, dfn)
+	assertLabel(t, "custom-site", "zone-test-custom-site.yaml", []string{"coherence.oracle.com/test"}, []string{}, fn, dfn)
 }
 
 // Verify that a Coherence resource deployed by the Operator has the correct rack value

--- a/utils/linkcheck/main.go
+++ b/utils/linkcheck/main.go
@@ -119,6 +119,7 @@ func run(cmd *cobra.Command) error {
 	excludes = append(excludes, "https://127.0.0.1")
 	excludes = append(excludes, "https://host")
 	excludes = append(excludes, "http://host")
+	excludes = append(excludes, "https://cert-manager.io")
 
 	exitCode, failedLinks := checkDocs(files, excludes)
 	if exitCode != 0 {


### PR DESCRIPTION
The Operator uses Node labels to configure the site and rack names for Coherence cluster members. The site and rack names need to be unique to achieve site safety of backups. In some environments the same values for the rack label are used for Nodes in different sites. To fix this the Operator will prefix the rack name with the site name to ensure they are unique. 