### PR TITLE
Apply Helm chart global labels and annotations to all resources in the chart

### DIFF
--- a/docs/other/041_global_labels.adoc
+++ b/docs/other/041_global_labels.adoc
@@ -183,5 +183,10 @@ helm install  \
     coherence/coherence-operator
 ----
 
+[NOTE]
+====
+When setting the Helm chart values `globalLabels` or `globalAnnotations` any labels and annotations specified will also
+be applied to all the resources installed by the Helm Chart too.
+====
 
 

--- a/helm-charts/coherence-operator/templates/deployment.yaml
+++ b/helm-charts/coherence-operator/templates/deployment.yaml
@@ -5,6 +5,14 @@ kind: Secret
 metadata:
   name: {{ default "coherence-webhook-server-cert" .Values.webhookCertSecret }}
   namespace: {{ .Release.Namespace }}
+{{- if (.Values.globalLabels) }}
+  labels:
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1
@@ -20,6 +28,13 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: webhook
@@ -44,6 +59,13 @@ metadata:
     app.kubernetes.io/component: rest
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: http-rest
@@ -69,11 +91,19 @@ metadata:
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/created-by: controller-manager
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
 {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
 {{- end }}
-{{- if .Values.deploymentAnnotations }}
+{{- if or (.Values.deploymentAnnotations) (.Values.globalAnnotations) }}
   annotations:
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
+{{- if .Values.deploymentAnnotations }}
 {{ toYaml .Values.deploymentAnnotations | indent 4 }}
 {{- end }}
 spec:
@@ -92,11 +122,19 @@ spec:
         app.kubernetes.io/part-of: coherence-operator
         app.kubernetes.io/managed-by: helm
         app.kubernetes.io/created-by: controller-manager
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 8 }}
+{{- end }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 8 }}
 {{- end }}
-{{- if .Values.annotations }}
+{{- if or (.Values.annotations) (.Values.globalAnnotations) }}
       annotations:
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+{{ toYaml .Values.globalAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:

--- a/helm-charts/coherence-operator/templates/rbac.yaml
+++ b/helm-charts/coherence-operator/templates/rbac.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 ---
 {{- if .Values.clusterRoles }}
 # -------------------------------------------------------------
@@ -21,6 +28,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 rules:
   - apiGroups:
     - apiextensions.k8s.io
@@ -54,6 +68,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -78,6 +99,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 rules:
 - apiGroups:
   - ""
@@ -99,6 +127,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -124,6 +159,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 rules:
 - apiGroups:
   - ""
@@ -225,6 +267,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- if .Values.clusterRoles }}
@@ -248,6 +297,13 @@ metadata:
   name: leader-election-role
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 rules:
 - apiGroups:
   - ""
@@ -291,6 +347,13 @@ metadata:
   name: leader-election-rolebinding
   labels:
     control-plane: coherence
+{{- if (.Values.globalLabels) }}
+{{ toYaml .Values.globalLabels | indent 4 }}
+{{- end }}
+{{- if (.Values.globalAnnotations) }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/e2e/helm/helm_test.go
+++ b/test/e2e/helm/helm_test.go
@@ -583,40 +583,138 @@ func TestGlobalLabelsAndAnnotations(t *testing.T) {
 		"--set", "globalAnnotations.four=annotation-four")
 	g.Expect(err).NotTo(HaveOccurred())
 	AssertHelmInstallWithStatefulSetSubTest(t, "basic", cmd, g, AssertLabelsAndAnnotations)
+}
 
-	//result, err := helmInstall("--set", "globalLabels.one=label-one",
-	//	"--set", "globalLabels.two=label-two",
-	//	"--set", "globalAnnotations.three=annotation-three",
-	//	"--set", "globalAnnotations.four=annotation-four")
-	//
-	//g.Expect(err).NotTo(HaveOccurred())
-	//g.Expect(result).NotTo(BeNil())
-	//
-	//dep := &appsv1.Deployment{}
-	//err = result.Get("coherence-operator", dep)
-	//g.Expect(err).NotTo(HaveOccurred())
-	//
-	//t.Logf("Asserting Helm install. Deploying Coherence resource")
-	//ns := helper.GetTestNamespace()
-	//deployment, err := helper.NewSingleCoherenceFromYaml(ns, "coherence.yaml")
-	//g.Expect(err).NotTo(HaveOccurred())
-	//
-	//defer deleteCoherence(t, &deployment)
-	//
-	//err = testContext.Client.Create(goctx.TODO(), &deployment)
-	//g.Expect(err).NotTo(HaveOccurred())
-	//
-	//var sts *appsv1.StatefulSet
-	//sts, err = helper.WaitForStatefulSetForDeployment(testContext, ns, &deployment, helper.RetryInterval, helper.Timeout)
-	//g.Expect(err).NotTo(HaveOccurred())
-	//
-	//g.Expect(sts.Labels).NotTo(BeNil())
-	//g.Expect(sts.Labels["one"]).To(Equal("label-one"))
-	//g.Expect(sts.Labels["two"]).To(Equal("label-two"))
-	//
-	//g.Expect(sts.Annotations).NotTo(BeNil())
-	//g.Expect(sts.Annotations["three"]).To(Equal("annotation-three"))
-	//g.Expect(sts.Annotations["four"]).To(Equal("annotation-four"))
+func TestGlobalLabelsOnOperatorResources(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	result, err := helmInstall("--set", "globalLabels.one=label-one",
+		"--set", "globalLabels.two=label-two")
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).NotTo(BeNil())
+
+	dep := &appsv1.Deployment{}
+	err = result.Get("coherence-operator", dep)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := dep.Labels
+	actual, found := labels["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-one"))
+	actual, found = labels["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-two"))
+
+	labels = dep.Spec.Template.Labels
+	actual, found = labels["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-one"))
+	actual, found = labels["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-two"))
+
+	svc := &corev1.Service{}
+	err = result.Get("coherence-operator-webhook", svc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels = svc.Labels
+	actual, found = labels["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-one"))
+	actual, found = labels["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-two"))
+
+	svc = &corev1.Service{}
+	err = result.Get("coherence-operator-rest", svc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels = svc.Labels
+	actual, found = labels["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-one"))
+	actual, found = labels["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-two"))
+
+	sec := &corev1.Secret{}
+	err = result.Get("coherence-webhook-server-cert", sec)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels = sec.Labels
+	actual, found = labels["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-one"))
+	actual, found = labels["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("label-two"))
+}
+
+func TestGlobalAnnotationsOnOperatorResources(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	result, err := helmInstall("--set", "globalAnnotations.one=annotation-one",
+		"--set", "globalAnnotations.two=annotation-two")
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).NotTo(BeNil())
+
+	dep := &appsv1.Deployment{}
+	err = result.Get("coherence-operator", dep)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	annotations := dep.Annotations
+	actual, found := annotations["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-one"))
+	actual, found = annotations["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-two"))
+
+	annotations = dep.Spec.Template.Annotations
+	actual, found = annotations["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-one"))
+	actual, found = annotations["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-two"))
+
+	svc := &corev1.Service{}
+	err = result.Get("coherence-operator-webhook", svc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	annotations = svc.Annotations
+	actual, found = annotations["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-one"))
+	actual, found = annotations["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-two"))
+
+	svc = &corev1.Service{}
+	err = result.Get("coherence-operator-rest", svc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	annotations = svc.Annotations
+	actual, found = annotations["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-one"))
+	actual, found = annotations["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-two"))
+
+	sec := &corev1.Secret{}
+	err = result.Get("coherence-webhook-server-cert", sec)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	annotations = sec.Annotations
+	actual, found = annotations["one"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-one"))
+	actual, found = annotations["two"]
+	g.Expect(found).To(BeTrue())
+	g.Expect(actual).To(Equal("annotation-two"))
 }
 
 func AssertLabelsAndAnnotations(t *testing.T, g *GomegaWithT, _ *coh.Coherence, sts *appsv1.StatefulSet) {


### PR DESCRIPTION
When specifying global labels or annotations values using the Helm chart, these labels and annotations will be applied to all the Operator resources installed by the chart