### PR TITLE
Do not specify a JVM garbage collector if none specified in the Coherence yaml

### DIFF
--- a/api/v1/create_statefulset_jvmspec_test.go
+++ b/api/v1/create_statefulset_jvmspec_test.go
@@ -221,7 +221,7 @@ func TestCreateStatefulSetWithJvmSpecWithGarbageCollector(t *testing.T) {
 	spec := coh.CoherenceResourceSpec{
 		JVM: &coh.JVMSpec{
 			Gc: &coh.JvmGarbageCollectorSpec{
-				Collector: stringPtr("G1"),
+				Collector: stringPtr("ZGC"),
 			},
 		},
 	}
@@ -230,7 +230,7 @@ func TestCreateStatefulSetWithJvmSpecWithGarbageCollector(t *testing.T) {
 	deployment := createTestDeployment(spec)
 	// Create expected StatefulSet
 	stsExpected := createMinimalExpectedStatefulSet(deployment)
-	addEnvVarsToAll(stsExpected, corev1.EnvVar{Name: "JVM_GC_COLLECTOR", Value: "G1"})
+	addEnvVarsToAll(stsExpected, corev1.EnvVar{Name: "JVM_GC_COLLECTOR", Value: "ZGC"})
 
 	// assert that the StatefulSet is as expected
 	assertStatefulSetCreation(t, deployment, stsExpected)

--- a/docs/jvm/040_gc.adoc
+++ b/docs/jvm/040_gc.adoc
@@ -61,13 +61,16 @@ If different GC logging arguments are required then the relevant JVM arguments c
 The garbage collector to use can be set using the `jvm.gc.collector` field.
 This field can be set to either `G1`, `CMS` or `Parallel`
 (the field is case-insensitive, invalid values will be silently ignored).
-The default collector set, if none has been specified, will be `G1`.
+
+The default collector set, if none has been specified, will be whatever is the default for the JVM being used.
 
 |====
 | Parameter  | JVM Argument Set
 | `G1`       | `-XX:+UseG1GC`
 | `CMS`      | `-XX:+UseConcMarkSweepGC`
 | `Parallel` | `-XX:+UseParallelGC`
+| `Serial`   | `-XX:+UseSerialGC`
+| `ZGC`      | `-XX:+UseZGC`
 |====
 
 For example:
@@ -80,9 +83,15 @@ metadata:
 spec:
   jvm:
     gc:
-      collector: "G1"
+      collector: "ZGC"
 ----
-The example above will add `-XX:+UseG1GC` to the command line.
+The example above will add `-XX:+UseZGC` to the command line.
+
+[NOTE]
+====
+The JVM only allows a single `-XX:Use****` option that sets the garbage collector to use, so the collector should not be
+specified in both the `spec.jvm.gc.collector` field, and in the `spec.jvm.args` field.
+====
 
 === Adding Arbitrary GC Args
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -426,12 +426,16 @@ func configureCommand(details *run_details.RunDetails) error {
 
 	gc := strings.ToLower(details.Getenv(v1.EnvVarJvmGcCollector))
 	switch {
-	case gc == "" || gc == "g1":
+	case gc == "g1":
 		details.AddMemoryOption("-XX:+UseG1GC")
 	case gc == "cms":
 		details.AddMemoryOption("-XX:+UseConcMarkSweepGC")
 	case gc == "parallel":
 		details.AddMemoryOption("-XX:+UseParallelGC")
+	case gc == "serial":
+		details.AddMemoryOption("-XX:+UseSerialGC")
+	case gc == "zgc":
+		details.AddMemoryOption("-XX:+UseZGC")
 	}
 
 	maxRAM := details.Getenv(v1.EnvVarJvmMaxRAM)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -217,7 +217,6 @@ func AppendCommonExpectedNonServerArgs(args []string, role string) []string {
 		"-Dcoherence.operator.diagnostics.dir=/coherence-operator/jvm/unknown/unknown",
 		"-XX:HeapDumpPath=/coherence-operator/jvm/unknown/unknown/heap-dumps/unknown-unknown.hprof",
 		"-Dcoherence.operator.can.resume.services=true",
-		"-XX:+UseG1GC",
 		"-Dcoherence.ttl=0",
 		"-XX:+UnlockDiagnosticVMOptions",
 		"-XX:ErrorFile=/coherence-operator/jvm/unknown/unknown/hs-err-unknown-unknown.log",


### PR DESCRIPTION
The Operator used to set the JVM arg `-XX:+UseG1GC` if nothing was specified for the `spec.jvm.gc.collector` field. This meant that it was impossible to set a collector that the Operator yaml did not recognise as this would cause two `-XX:+Use***` JVM args and the JVM would not start.

If the `spec.jvm.gc.collector` is not set the Operator does not set any GC collector JVM arg. The `spec.jvm.gc.collector` field now also supports `serial` and `zgc` as additional values.