### PR TITLE
The Operator should not use https and access control on its own metrics endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -753,6 +753,9 @@ endif
 # Build the Java artifacts
 # ----------------------------------------------------------------------------------------------------------------------
 .PHONY: build-mvn
+build-mvn: $(BUILD_TARGETS)/java
+
+.PHONY: build-java
 build-mvn: $(BUILD_TARGETS)/java ## Build the Java artefacts
 
 $(BUILD_TARGETS)/java: $(JAVA_FILES)

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,15 +12,22 @@ resources:
   - ../crd-small
   - ../rbac
   - ../manager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
   - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# [PROMETHEUS] uncomment the line below to enable prometheus monitor.
+#- ../prometheus
+# [NETWORK POLICY] Protect the /metrics endpoint with a NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
+
+# [Secure Metrics] To enable https and access control for metrics uncomment the patches below
+#patches:
+#  - path: manager_metrics_patch.yaml
+#    target:
+#      kind: Deployment
+#      name: controller-manager
 
 labels:
   - pairs:

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -2,3 +2,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --metrics-bind-address=:8443
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-secure=true

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -2,13 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: metrics-service
-  namespace: system
+  namespace: default
 spec:
   ports:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: 8443
+    targetPort: metrics-https
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,9 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+        - containerPort: 8443
+          name: metrics-https
+          protocol: TCP
         - containerPort: 8088
           name: health
           protocol: TCP

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: "3.5.6"
     app.kubernetes.io/part-of: coherence-operator
   name: allow-metrics-traffic
-  namespace: system
+  namespace: default
 spec:
   podSelector:
     matchLabels:

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
+# If using secure metrics comment out the monitor-http.yaml
+# resource and uncomment the monitor.yaml resource
 resources:
-- monitor.yaml
+- monitor-http.yaml
+#- monitor.yaml

--- a/config/prometheus/monitor-http.yaml
+++ b/config/prometheus/monitor-http.yaml
@@ -1,0 +1,24 @@
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: coherence
+    app.kubernetes.io/name: coherence-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/version: "3.5.6"
+    app.kubernetes.io/part-of: coherence-operator
+  name: controller-manager-metrics-monitor
+  namespace: default
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+      scheme: http
+  selector:
+    matchLabels:
+      control-plane: coherence
+      app.kubernetes.io/name: coherence-operator
+      app.kubernetes.io/instance: coherence-operator-manager
+      app.kubernetes.io/version: "3.5.6"
+      app.kubernetes.io/component: manager

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "3.5.6"
     app.kubernetes.io/part-of: coherence-operator
   name: controller-manager-metrics-monitor
-  namespace: system
+  namespace: default
 spec:
   endpoints:
     - path: /metrics

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: default

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -154,7 +154,7 @@ func SetupFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().Bool(
 		FlagEnableHttp2,
 		false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers",
+		"If set, HTTP/2 will be enabled for the metrics and REST servers",
 	)
 	cmd.Flags().Bool(
 		FlagEnableWebhook,
@@ -188,7 +188,7 @@ func SetupFlags(cmd *cobra.Command, v *viper.Viper) {
 	)
 	cmd.Flags().Bool(
 		FlagSecureMetrics,
-		true,
+		false,
 		"FlagSecureMetrics",
 	)
 	cmd.Flags().String(


### PR DESCRIPTION
The operator previously enabled https and access control for its own metrics endpoint by default. This made metrics pretty much unusable out of the box unless the customer understands the various ways to enable access.