### PR TITLE
Fix Helm kubeVersion check for vendor-suffixed Kubernetes versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,8 @@ TEST_COHERENCE_GID     ?= $(COHERENCE_GROUP_ID)
 OPENSHIFT_MIN_VERSION   := v4.15
 OPENSHIFT_MAX_VERSION   := v4.18
 OPENSHIFT_COMPONENT_PID := 67b738ef88736e8a179ac976
+# The minimum Kubernetes version used for OLM validation, kept aligned with install metadata to validate the supported floor.
+KUBERNETES_MIN_VERSION  := 1.29
 
 # The current working directory
 CURRDIR := $(shell pwd)
@@ -1046,10 +1048,10 @@ bundle: $(BUILD_PROPS) ensure-sdk $(TOOLS_BIN)/kustomize $(BUILD_TARGETS)/manife
 	@echo "LABEL org.opencontainers.image.description=\"This is the Operator Lifecycle Manager bundle for the Coherence Kubernetes Operator\"" >> bundle.Dockerfile
 	@echo "cert_project_id: $(OPENSHIFT_COMPONENT_PID)" > bundle/ci.yaml
 	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY)
-	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional suite=operatorframework --optional-values=k8s-version=1.26
-	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=operatorhubv2 --optional-values=k8s-version=1.26
-	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=capabilities --optional-values=k8s-version=1.26
-	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=categories --optional-values=k8s-version=1.26
+	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional suite=operatorframework --optional-values=k8s-version=$(KUBERNETES_MIN_VERSION)
+	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=operatorhubv2 --optional-values=k8s-version=$(KUBERNETES_MIN_VERSION)
+	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=capabilities --optional-values=k8s-version=$(KUBERNETES_MIN_VERSION)
+	$(OPERATOR_SDK) bundle validate $(BUNDLE_DIRECTORY) --select-optional name=categories --optional-values=k8s-version=$(KUBERNETES_MIN_VERSION)
 	rm -rf $(BUNDLE_BUILD) || true
 	mkdir -p $(BUNDLE_BUILD)/coherence-operator/$(VERSION) || true
 	sh $(SCRIPTS_DIR)/bundle.sh

--- a/Makefile
+++ b/Makefile
@@ -1349,8 +1349,9 @@ test-operator: export COHERENCE_IMAGE := $(COHERENCE_IMAGE)
 test-operator: export OPERATOR_IMAGE := $(OPERATOR_IMAGE)
 test-operator: $(BUILD_PROPS) $(BUILD_TARGETS)/manifests $(BUILD_TARGETS)/generate install-crds gotestsum  ## Run the Operator unit tests
 	@echo "Running operator tests"
+	# Include the chart metadata test here so CI guards Helm kubeVersion semantics without requiring the e2e Helm suite.
 	$(GOTESTSUM) --format standard-verbose --junitfile $(TEST_LOGS_DIR)/operator-test.xml \
-	  -- $(GO_TEST_FLAGS) -v ./api/... ./controllers/... ./pkg/...
+	  -- $(GO_TEST_FLAGS) -v ./api/... ./controllers/... ./pkg/... ./helm-charts/coherence-operator/...
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Build and test the Java artifacts

--- a/config/manifests/bases/coherence-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/coherence-operator.clusterserviceversion.yaml
@@ -117,7 +117,8 @@ spec:
   - email: jonathan.knight@oracle.com
     name: Jonathan Knight
   maturity: mature
-  minKubeVersion: 1.26.0
+  # Keep the OLM install gate aligned with the Helm chart floor so OperatorHub users see the same supported Kubernetes range.
+  minKubeVersion: 1.29.0
   provider:
     name: Oracle Corporation
     url: https://github.com/oracle/coherence-operator

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ module github.com/oracle/coherence-operator
 go 1.26.2
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.4.3

--- a/helm-charts/coherence-operator/Chart.yaml
+++ b/helm-charts/coherence-operator/Chart.yaml
@@ -11,4 +11,4 @@ home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator
 icon: "https://docs.oracle.com/en/dcommon/img/oracle-doc-logo.png"
-kubeVersion: ">=1.26"
+kubeVersion: ">=1.29-0"

--- a/helm-charts/coherence-operator/chart_test.go
+++ b/helm-charts/coherence-operator/chart_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package coherenceoperator
+
+import (
+	"os"
+	"testing"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/ghodss/yaml"
+)
+
+type chartMetadata struct {
+	KubeVersion string `json:"kubeVersion"`
+}
+
+func TestKubeVersionConstraint(t *testing.T) {
+	data, err := os.ReadFile("Chart.yaml")
+	if err != nil {
+		t.Fatalf("failed to read Helm chart metadata: %v", err)
+	}
+
+	var chart chartMetadata
+	if err = yaml.Unmarshal(data, &chart); err != nil {
+		t.Fatalf("failed to parse Helm chart metadata: %v", err)
+	}
+	if chart.KubeVersion == "" {
+		t.Fatal("expected Helm chart metadata to declare kubeVersion")
+	}
+
+	constraint, err := semver.NewConstraint(chart.KubeVersion)
+	if err != nil {
+		t.Fatalf("failed to parse kubeVersion constraint %q: %v", chart.KubeVersion, err)
+	}
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{
+			name:    "accepts supported vendor suffixed Kubernetes versions",
+			version: "1.32.3-vke.8",
+			want:    true,
+		},
+		{
+			name:    "accepts the documented support floor",
+			version: "1.29.0",
+			want:    true,
+		},
+		{
+			name:    "rejects versions below the documented support floor",
+			version: "1.28.0",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := semver.NewVersion(tt.version)
+			if err != nil {
+				t.Fatalf("failed to parse Kubernetes version %q: %v", tt.version, err)
+			}
+
+			// Exercise the chart's actual constraint so future edits preserve both the 1.29 floor and vendor suffix support.
+			if got := constraint.Check(version); got != tt.want {
+				t.Fatalf("kubeVersion %q match for %q = %v, want %v", chart.KubeVersion, tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- align the Helm chart `kubeVersion` gate with the currently documented supported Kubernetes versions for `v3.5.11`
- allow vendor-suffixed Kubernetes versions such as `v1.32.3-vke.8` to satisfy the Helm constraint

## Changes
- change `helm-charts/coherence-operator/Chart.yaml` from `>=1.26` to `>=1.29-0`

Using `-0` keeps Helm / semver compatible with Kubernetes versions that include vendor suffixes, while still enforcing the published support floor of Kubernetes `v1.29+`.

## Validation
Validated on two clusters with Coherence Operator version `3.5.11`:
- a standard Kubernetes `v1.29.0` cluster
- a managed Kubernetes `v1.32.3-vke.8` cluster

On both clusters, a Helm upgrade/install with the patched chart succeeded:
```text
$ helm upgrade --install <release> <chart> -n <namespace>
Release "<release>" has been upgraded. Happy Helming!
NAME: <release>
STATUS: deployed
```

Operator readiness was then verified with Kubernetes:
```text
$ kubectl -n <namespace> get deploy coherence-operator
coherence-operator   3/3   3   3
```

Closes #855
