### PR TITLE
 COH-33517 Add configurable IP families for the Operator REST Service

### DIFF
--- a/.github/actions/setup-oras-1.2.1/action.yml
+++ b/.github/actions/setup-oras-1.2.1/action.yml
@@ -28,5 +28,5 @@ inputs:
     description: SHA256 of the customized ORAS CLI. Required if 'url' is present.
     required: false
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
 #   Checkout the source, we need a depth of zero to fetch all of the history otherwise
 #   the copyright check cannot work out the date of the files from Git.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -93,7 +93,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -167,7 +167,7 @@ jobs:
         make fips-test
 
     - name: Upload Manifests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: success()
       with:
         name: coherence-operator-manifests.tar.gz
@@ -175,7 +175,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Upload Yaml
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: success()
       with:
         name: coherence-operator.yaml
@@ -183,14 +183,14 @@ jobs:
         if-no-files-found: ignore
 
     - name: Upload CRD
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: success()
       with:
         name: coherence.oracle.com_coherence.yaml
         path: build/_output/manifests/crd/coherence.oracle.com_coherence.yaml
         if-no-files-found: ignore
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output

--- a/.github/workflows/coherence-matrix.yaml
+++ b/.github/workflows/coherence-matrix.yaml
@@ -140,7 +140,7 @@ jobs:
             baseImage: "gcr.io/distroless/java11-debian11"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
 #        go-version-file: go.mod
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -186,7 +186,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -286,7 +286,7 @@ jobs:
         collect coherence-crds kubectl get crd coherence.coherence.oracle.com coherencejob.coherence.oracle.com
         collect coherence-resources kubectl get coherence.coherence.oracle.com,coherencejob.coherence.oracle.com -A
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output-${{ matrix.matrixName }}

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -81,7 +81,7 @@ jobs:
           k8s: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -114,7 +114,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -122,7 +122,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -172,7 +172,7 @@ jobs:
         export COMPATIBLE_SELECTOR=${{ matrix.compatibilitySelector }}
         make compatibility-test
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output-${{ matrix.compatibilityVersion }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -45,7 +45,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/dual-stack.yaml
+++ b/.github/workflows/dual-stack.yaml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           release: 21
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-go-mods-
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/dual-stack.yaml
+++ b/.github/workflows/dual-stack.yaml
@@ -53,6 +53,9 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Validate verification script syntax
+        run: bash -n hack/kind/verify-operator-rest-dual-stack.sh
+
       - name: Start dual-stack KinD cluster
         run: make kind-dual
 
@@ -62,24 +65,63 @@ jobs:
       - name: Load operator image
         run: make kind-load-operator
 
-      - name: Install dual-stack REST Service
+      - name: Verify REST Service IP-family matrix
         run: |
-          chart_version="$(<build/_output/version.txt)"
-          helm upgrade --install coherence-operator "build/_output/helm-charts/coherence-operator-${chart_version}.tgz" \
-            --namespace operator-test \
-            --create-namespace \
-            --set replicas=1 \
-            --set restService.ipFamilyPolicy=RequireDualStack \
-            --set 'restService.ipFamilies={IPv4,IPv6}' \
-            --wait \
-            --timeout 5m
+          set -o errexit
+          set -o nounset
+          set -o pipefail
 
-      - name: Verify IPv4 and IPv6 REST access
-        run: hack/kind/verify-operator-rest-dual-stack.sh
+          chart_version="$(<build/_output/version.txt)"
+          chart="build/_output/helm-charts/coherence-operator-${chart_version}.tgz"
+
+          verify_scenario() {
+            local scenario="$1"
+            local expected_policy="$2"
+            local expected_families_csv="$3"
+            local configured_policy="$4"
+            local configured_families="$5"
+            local expected_families=()
+            local helm_args=(--set replicas=1)
+
+            IFS=',' read -r -a expected_families <<< "${expected_families_csv}"
+            if [[ -n "${configured_policy}" ]]; then
+              helm_args+=(--set "restService.ipFamilyPolicy=${configured_policy}")
+            fi
+            if [[ -n "${configured_families}" ]]; then
+              helm_args+=(--set "restService.ipFamilies={${configured_families}}")
+            fi
+
+            echo "Verifying scenario: ${scenario}"
+            helm upgrade --install coherence-operator "${chart}" \
+              --namespace operator-test \
+              --create-namespace \
+              --wait \
+              --timeout 5m \
+              "${helm_args[@]}"
+
+            hack/kind/verify-operator-rest-dual-stack.sh \
+              operator-test coherence-operator-rest "${expected_policy}" "${expected_families[@]}"
+
+            helm uninstall coherence-operator --namespace operator-test --wait --timeout 5m
+            kubectl --namespace operator-test wait --for=delete \
+              service/coherence-operator-rest --timeout=2m
+          }
+
+          verify_scenario default SingleStack IPv4 "" ""
+          verify_scenario single-stack-ipv4 SingleStack IPv4 SingleStack IPv4
+          verify_scenario single-stack-ipv6 SingleStack IPv6 SingleStack IPv6
+          verify_scenario prefer-dual-stack-ipv4-first PreferDualStack IPv4,IPv6 PreferDualStack IPv4,IPv6
+          verify_scenario prefer-dual-stack-ipv6-first PreferDualStack IPv6,IPv4 PreferDualStack IPv6,IPv4
+          verify_scenario require-dual-stack-ipv4-first RequireDualStack IPv4,IPv6 RequireDualStack IPv4,IPv6
+          verify_scenario require-dual-stack-ipv6-first RequireDualStack IPv6,IPv4 RequireDualStack IPv6,IPv4
 
       - name: Collect diagnostics
         if: ${{ failure() || cancelled() }}
         run: |
           kubectl get all --all-namespaces -o wide
-          kubectl --namespace operator-test describe service coherence-operator-rest || true
+          kubectl --namespace operator-test get service coherence-operator-rest -o yaml || true
+          kubectl --namespace operator-test get endpointslices \
+            --selector kubernetes.io/service-name=coherence-operator-rest -o yaml || true
+          kubectl --namespace operator-test get pods \
+            -o custom-columns='NAME:.metadata.name,POD_IPS:.status.podIPs[*].ip,NODE:.spec.nodeName' || true
           kubectl --namespace operator-test logs deployment/coherence-operator --all-pods=true || true

--- a/.github/workflows/dual-stack.yaml
+++ b/.github/workflows/dual-stack.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+name: Operator REST Dual Stack
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - gh-pages
+      - 1.0.0
+      - 2.x
+      - 3.x
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches-ignore:
+      - gh-pages
+      - 1.0.0
+      - 2.x
+      - 3.x
+
+jobs:
+  dual-stack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: oracle-actions/setup-java@v1
+        with:
+          website: oracle.com
+          release: 21
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mods-
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Start dual-stack KinD cluster
+        run: make kind-dual
+
+      - name: Build operator image and Helm chart
+        run: make build-operator helm-chart
+
+      - name: Load operator image
+        run: make kind-load-operator
+
+      - name: Install dual-stack REST Service
+        run: |
+          chart_version="$(<build/_output/version.txt)"
+          helm upgrade --install coherence-operator "build/_output/helm-charts/coherence-operator-${chart_version}.tgz" \
+            --namespace operator-test \
+            --create-namespace \
+            --set replicas=1 \
+            --set restService.ipFamilyPolicy=RequireDualStack \
+            --set 'restService.ipFamilies={IPv4,IPv6}' \
+            --wait \
+            --timeout 5m
+
+      - name: Verify IPv4 and IPv6 REST access
+        run: hack/kind/verify-operator-rest-dual-stack.sh
+
+      - name: Collect diagnostics
+        if: ${{ failure() || cancelled() }}
+        run: |
+          kubectl get all --all-namespaces -o wide
+          kubectl --namespace operator-test describe service coherence-operator-rest || true
+          kubectl --namespace operator-test logs deployment/coherence-operator --all-pods=true || true

--- a/.github/workflows/istio-tests.yaml
+++ b/.github/workflows/istio-tests.yaml
@@ -43,7 +43,7 @@ jobs:
         - 1.22.8
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -88,7 +88,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -132,7 +132,7 @@ jobs:
         make undeploy
         ISTIO_VERSION=${{ matrix.istioVersion }} make uninstall-istio
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output-${{ matrix.istioVersion }}

--- a/.github/workflows/k3d-tests.yaml
+++ b/.github/workflows/k3d-tests.yaml
@@ -37,7 +37,7 @@ jobs:
 #   Checkout the source, we need a depth of zero to fetch all the history otherwise
 #   the copyright check cannot work out the date of the files from Git.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -78,7 +78,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -110,7 +110,7 @@ jobs:
       run: |
         make e2e-k3d-test
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output

--- a/.github/workflows/k8s-matrix.yaml
+++ b/.github/workflows/k8s-matrix.yaml
@@ -86,7 +86,7 @@ jobs:
             runNetTests: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -127,7 +127,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -158,7 +158,7 @@ jobs:
         export RUN_NET_TEST=${{ matrix.runNetTests }}
         ./hack/k8s-certification.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output-${{ matrix.matrixName }}

--- a/.github/workflows/minikube-matrix.yaml
+++ b/.github/workflows/minikube-matrix.yaml
@@ -56,7 +56,7 @@ jobs:
             k8s: v1.31.9
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -113,7 +113,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -146,7 +146,7 @@ jobs:
         make helm-chart
         make certification-test
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output-${{ matrix.matrixName }}

--- a/.github/workflows/prometheus-tests.yaml
+++ b/.github/workflows/prometheus-tests.yaml
@@ -37,7 +37,7 @@ jobs:
 #   Checkout the source, we need a depth of zero to fetch all the history otherwise
 #   the copyright check cannot work out the date of the files from Git.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -78,7 +78,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -149,7 +149,7 @@ jobs:
         collect coherence-crds kubectl get crd coherence.coherence.oracle.com coherencejob.coherence.oracle.com
         collect coherence-resources kubectl get coherence.coherence.oracle.com,coherencejob.coherence.oracle.com -A
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output

--- a/.github/workflows/tanzu-tests.yaml
+++ b/.github/workflows/tanzu-tests.yaml
@@ -41,7 +41,7 @@ jobs:
         - latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -82,7 +82,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -130,14 +130,14 @@ jobs:
         make kind-load
         make run-certification OPERATOR_NAMESPACE=coherence
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: tanzu-artifacts
         path: build/_output/tanzu
         if-no-files-found: ignore
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ failure() || cancelled() }}
       with:
         name: test-output

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
         release: 21
 
     - name: Cache Go Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-mods-${{ hashFiles('**/go.sum') }}
@@ -46,7 +46,7 @@ jobs:
           ${{ runner.os }}-go-mods-
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/docs/installation/012_install_helm.adoc
+++ b/docs/installation/012_install_helm.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2025, Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026, Oracle and/or its affiliates.
     Licensed under the Universal Permissive License v 1.0 as shown at
     http://oss.oracle.com/licenses/upl.
 
@@ -190,6 +190,71 @@ helm install  \
 ----
 
 The `payments`, `catalog` and `customers` namespaces will be watched by the Operator.
+
+[#helm-rest-service-ip-families]
+=== Configure the Operator REST Service IP Families
+
+The `restService.ipFamilyPolicy` and `restService.ipFamilies` values configure the corresponding
+Kubernetes fields on the `coherence-operator-rest` Service. Both values are unset by default, so
+Kubernetes applies the cluster's normal Service defaults. Either value may be set independently.
+
+Valid values for `restService.ipFamilyPolicy` are `SingleStack`, `PreferDualStack`, and
+`RequireDualStack`. The `restService.ipFamilies` value is an ordered list containing at most two
+distinct entries, each of which must be `IPv4` or `IPv6`.
+
+The following values configure an IPv4-only REST Service:
+
+[source,yaml]
+----
+restService:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+----
+
+For an IPv6-only REST Service, use:
+
+[source,yaml]
+----
+restService:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv6
+----
+
+For a dual-stack REST Service with IPv4 as the primary family, use:
+
+[source,yaml]
+----
+restService:
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+----
+
+The family order can be reversed to make IPv6 primary:
+
+[source,yaml]
+----
+restService:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv6
+    - IPv4
+----
+
+Helm validates the value types, policy and family names, family count, and uniqueness. Kubernetes
+still validates whether the requested policy and family combination is supported by the target
+cluster. If it is not supported, the Kubernetes API server rejects the Service and the Helm install
+or upgrade fails.
+
+Separately from these Service settings, the Operator REST listener binds to the unspecified wildcard
+address by default. This allows IPv4 and IPv6 connections when the platform supports dual-stack
+sockets, and falls back to IPv4 when IPv6 is unavailable. The `--rest-host` flag remains available for
+an explicit bind address; use `0.0.0.0` for an IPv4-only wildcard, `::` for an IPv6 wildcard, or
+specify an individual IPv4 or IPv6 address. IPv6 addresses may optionally be enclosed in square
+brackets. Changing the listener address does not change the Service's IP-family allocation.
 
 ==== Set the Watch Namespace to the Operator's Install Namespace
 
@@ -617,4 +682,3 @@ To uninstall the operator:
 ----
 helm delete coherence-operator --namespace <namespace>
 ----
-

--- a/hack/kind/verify-operator-rest-dual-stack.sh
+++ b/hack/kind/verify-operator-rest-dual-stack.sh
@@ -12,12 +12,140 @@ set -o pipefail
 
 namespace="${1:-operator-test}"
 service_name="${2:-coherence-operator-rest}"
+expected_policy="${3:-RequireDualStack}"
 probe_name="coherence-operator-rest-dual-stack-probe"
+missing_resource="coherence-operator-rest-verification-does-not-exist"
+endpoint_slices=""
+
+if (( $# >= 4 )); then
+  expected_families=("${@:4}")
+else
+  expected_families=(IPv4 IPv6)
+fi
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+ip_family() {
+  if [[ "$1" == *:* ]]; then
+    echo IPv6
+  else
+    echo IPv4
+  fi
+}
+
+assert_dual_stack_pod() {
+  local pod_name="$1"
+  local pod_ips=()
+  local ip
+  local has_ipv4=false
+  local has_ipv6=false
+
+  mapfile -t pod_ips < <(
+    kubectl --namespace "${namespace}" get pod "${pod_name}" \
+      -o jsonpath='{range .status.podIPs[*]}{.ip}{"\n"}{end}'
+  )
+  for ip in "${pod_ips[@]}"; do
+    if [[ "$(ip_family "${ip}")" == IPv4 ]]; then
+      has_ipv4=true
+    else
+      has_ipv6=true
+    fi
+  done
+  if [[ "${has_ipv4}" != true || "${has_ipv6}" != true ]]; then
+    fail "Expected Pod ${pod_name} to have IPv4 and IPv6 addresses, found ${pod_ips[*]:-<none>}"
+  fi
+}
+
+probe_http() {
+  local description="$1"
+  local expected_ip="$2"
+  shift 2
+  local output=""
+  local metadata=""
+  local body=""
+  local http_code=""
+  local remote_ip=""
+  local attempt
+
+  for attempt in 1 2 3 4 5; do
+    if output="$(
+      kubectl --namespace "${namespace}" exec "${probe_name}" -- \
+        curl --noproxy '*' --silent --show-error --connect-timeout 5 --max-time 10 \
+          --write-out $'\n%{http_code}\t%{remote_ip}' "$@"
+    )"; then
+      metadata="${output##*$'\n'}"
+      body="${output%$'\n'*}"
+      http_code="${metadata%%$'\t'*}"
+      remote_ip="${metadata#*$'\t'}"
+      if [[ "${http_code}" == 404 && "${remote_ip}" == "${expected_ip}" && "${body}" == *'"Actual": "NotFound"'* ]]; then
+        return 0
+      fi
+      echo "${description} returned HTTP ${http_code}, remote IP ${remote_ip}, body: ${body}" >&2
+    fi
+    if (( attempt < 5 )); then
+      echo "${description} failed on attempt ${attempt}; retrying in 2 seconds" >&2
+      sleep 2
+    fi
+  done
+  fail "${description} failed after 5 attempts"
+}
+
+wait_for_endpoint_slices() {
+  local attempt
+  local family
+  local ready_count
+  local ready
+  local endpoint_families=()
+
+  for attempt in {1..30}; do
+    endpoint_slices="$(
+      kubectl --namespace "${namespace}" get endpointslices \
+        --selector "kubernetes.io/service-name=${service_name}" -o json
+    )"
+    mapfile -t endpoint_families < <(
+      jq -r '[.items[].addressType] | unique[]' <<<"${endpoint_slices}"
+    )
+    ready=true
+    if [[ "${endpoint_families[*]}" != "${sorted_expected_families[*]}" ]]; then
+      ready=false
+    fi
+    for family in "${expected_families[@]}"; do
+      ready_count="$(
+        jq -r --arg family "${family}" '
+          [.items[] | select(.addressType == $family) |
+           .endpoints[] | select(.conditions.ready != false) | .addresses[]] | length
+        ' <<<"${endpoint_slices}"
+      )"
+      if (( ready_count == 0 )); then
+        ready=false
+      fi
+    done
+    if [[ "${ready}" == true ]]; then
+      return 0
+    fi
+    if (( attempt < 30 )); then
+      sleep 2
+    fi
+  done
+  fail "EndpointSlices did not publish ready endpoints for families ${expected_families[*]} within 60 seconds"
+}
+
+if (( ${#expected_families[@]} < 1 || ${#expected_families[@]} > 2 )); then
+  fail "Expected one or two IP families, found ${expected_families[*]:-<none>}"
+fi
+for family in "${expected_families[@]}"; do
+  if [[ "${family}" != IPv4 && "${family}" != IPv6 ]]; then
+    fail "Unsupported expected IP family ${family}"
+  fi
+done
+command -v jq >/dev/null || fail "jq is required to verify EndpointSlices"
 
 policy="$(kubectl --namespace "${namespace}" get service "${service_name}" -o jsonpath='{.spec.ipFamilyPolicy}')"
-if [[ "${policy}" != "RequireDualStack" ]]; then
-  echo "Expected ipFamilyPolicy RequireDualStack, found ${policy}" >&2
-  exit 1
+if [[ "${policy}" != "${expected_policy}" ]]; then
+  fail "Expected ipFamilyPolicy ${expected_policy}, found ${policy}"
 fi
 
 mapfile -t families < <(
@@ -29,26 +157,59 @@ mapfile -t cluster_ips < <(
     -o jsonpath='{range .spec.clusterIPs[*]}{@}{"\n"}{end}'
 )
 
-expected_families=(IPv4 IPv6)
-if [[ "${#families[@]}" -ne 2 || "${families[0]}" != "${expected_families[0]}" || "${families[1]}" != "${expected_families[1]}" ]]; then
-  echo "Expected ipFamilies IPv4,IPv6, found ${families[*]:-<none>}" >&2
-  exit 1
+if [[ "${families[*]}" != "${expected_families[*]}" ]]; then
+  fail "Expected ipFamilies ${expected_families[*]}, found ${families[*]:-<none>}"
 fi
-if [[ "${#cluster_ips[@]}" -ne 2 ]]; then
-  echo "Expected two cluster IPs, found ${cluster_ips[*]:-<none>}" >&2
-  exit 1
+if [[ "${#cluster_ips[@]}" -ne "${#expected_families[@]}" ]]; then
+  fail "Expected ${#expected_families[@]} cluster IPs, found ${cluster_ips[*]:-<none>}"
 fi
 
-for index in 0 1; do
+declare -A seen_cluster_ips=()
+for index in "${!expected_families[@]}"; do
   ip="${cluster_ips[${index}]}"
-  if [[ "${families[${index}]}" == "IPv4" && "${ip}" == *:* ]]; then
-    echo "Expected IPv4 cluster IP at index ${index}, found ${ip}" >&2
-    exit 1
+  if [[ "$(ip_family "${ip}")" != "${families[${index}]}" ]]; then
+    fail "Expected ${families[${index}]} cluster IP at index ${index}, found ${ip}"
   fi
-  if [[ "${families[${index}]}" == "IPv6" && "${ip}" != *:* ]]; then
-    echo "Expected IPv6 cluster IP at index ${index}, found ${ip}" >&2
-    exit 1
+  if [[ -n "${seen_cluster_ips[${ip}]:-}" ]]; then
+    fail "Expected unique cluster IPs, found duplicate ${ip}"
   fi
+  seen_cluster_ips["${ip}"]=true
+done
+
+mapfile -t sorted_expected_families < <(printf '%s\n' "${expected_families[@]}" | sort -u)
+wait_for_endpoint_slices
+
+operator_pods=()
+for family in "${expected_families[@]}"; do
+  mapfile -t endpoint_addresses < <(
+    jq -r --arg family "${family}" '
+      .items[] | select(.addressType == $family) |
+      .endpoints[] | select(.conditions.ready != false) | .addresses[]
+    ' <<<"${endpoint_slices}"
+  )
+  if (( ${#endpoint_addresses[@]} == 0 )); then
+    fail "Expected at least one ready ${family} endpoint for Service ${service_name}"
+  fi
+  for ip in "${endpoint_addresses[@]}"; do
+    if [[ "$(ip_family "${ip}")" != "${family}" ]]; then
+      fail "EndpointSlice declared ${family} but contained address ${ip}"
+    fi
+  done
+  mapfile -t family_pods < <(
+    jq -r --arg family "${family}" '
+      .items[] | select(.addressType == $family) |
+      .endpoints[] | select(.conditions.ready != false) |
+      select(.targetRef.kind == "Pod") | .targetRef.name
+    ' <<<"${endpoint_slices}"
+  )
+  operator_pods+=("${family_pods[@]}")
+done
+mapfile -t operator_pods < <(printf '%s\n' "${operator_pods[@]}" | sed '/^$/d' | sort -u)
+if (( ${#operator_pods[@]} == 0 )); then
+  fail "Expected EndpointSlices for ${service_name} to target at least one Pod"
+fi
+for pod_name in "${operator_pods[@]}"; do
+  assert_dual_stack_pod "${pod_name}"
 done
 
 kubectl --namespace "${namespace}" delete pod "${probe_name}" --ignore-not-found
@@ -58,32 +219,23 @@ kubectl --namespace "${namespace}" run "${probe_name}" \
   --restart=Never \
   --command -- sleep 600
 kubectl --namespace "${namespace}" wait --for=condition=Ready "pod/${probe_name}" --timeout=2m
+assert_dual_stack_pod "${probe_name}"
 
-for ip in "${cluster_ips[@]}"; do
-  if [[ "${ip}" == *:* ]]; then
-    url="http://[${ip}]:8000/"
+status_path="/status/${namespace}/${missing_resource}"
+service_host="${service_name}.${namespace}.svc"
+for index in "${!expected_families[@]}"; do
+  family="${expected_families[${index}]}"
+  ip="${cluster_ips[${index}]}"
+  if [[ "${family}" == IPv6 ]]; then
+    direct_url="http://[${ip}]:8000${status_path}"
+    curl_family=-6
   else
-    url="http://${ip}:8000/"
+    direct_url="http://${ip}:8000${status_path}"
+    curl_family=-4
   fi
-
-  # The root path may return any HTTP status; receiving a response is sufficient
-  # because this check verifies REST listener reachability through each Service IP.
-  reachable=false
-  for attempt in 1 2 3 4 5; do
-    if kubectl --namespace "${namespace}" exec "${probe_name}" -- \
-      curl --noproxy '*' --silent --show-error --connect-timeout 5 --max-time 10 --output /dev/null "${url}"; then
-      reachable=true
-      break
-    fi
-    if ((attempt < 5)); then
-      echo "REST probe to ${url} failed on attempt ${attempt}; retrying in 2 seconds" >&2
-      sleep 2
-    fi
-  done
-  if [[ "${reachable}" != "true" ]]; then
-    echo "REST probe to ${url} failed after 5 attempts" >&2
-    exit 1
-  fi
+  probe_http "Direct ${family} REST probe to ${direct_url}" "${ip}" "${direct_url}"
+  dns_url="http://${service_host}:8000${status_path}"
+  probe_http "DNS ${family} REST probe to ${dns_url}" "${ip}" "${curl_family}" "${dns_url}"
 done
 
-echo "Verified ${service_name} through IPv4 ${cluster_ips[0]} and IPv6 ${cluster_ips[1]}"
+echo "Verified ${service_name}: policy=${policy}, families=${families[*]}, clusterIPs=${cluster_ips[*]}"

--- a/hack/kind/verify-operator-rest-dual-stack.sh
+++ b/hack/kind/verify-operator-rest-dual-stack.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+namespace="${1:-operator-test}"
+service_name="${2:-coherence-operator-rest}"
+probe_name="coherence-operator-rest-dual-stack-probe"
+
+policy="$(kubectl --namespace "${namespace}" get service "${service_name}" -o jsonpath='{.spec.ipFamilyPolicy}')"
+if [[ "${policy}" != "RequireDualStack" ]]; then
+  echo "Expected ipFamilyPolicy RequireDualStack, found ${policy}" >&2
+  exit 1
+fi
+
+mapfile -t families < <(
+  kubectl --namespace "${namespace}" get service "${service_name}" \
+    -o jsonpath='{range .spec.ipFamilies[*]}{@}{"\n"}{end}'
+)
+mapfile -t cluster_ips < <(
+  kubectl --namespace "${namespace}" get service "${service_name}" \
+    -o jsonpath='{range .spec.clusterIPs[*]}{@}{"\n"}{end}'
+)
+
+expected_families=(IPv4 IPv6)
+if [[ "${#families[@]}" -ne 2 || "${families[0]}" != "${expected_families[0]}" || "${families[1]}" != "${expected_families[1]}" ]]; then
+  echo "Expected ipFamilies IPv4,IPv6, found ${families[*]:-<none>}" >&2
+  exit 1
+fi
+if [[ "${#cluster_ips[@]}" -ne 2 ]]; then
+  echo "Expected two cluster IPs, found ${cluster_ips[*]:-<none>}" >&2
+  exit 1
+fi
+
+for index in 0 1; do
+  ip="${cluster_ips[${index}]}"
+  if [[ "${families[${index}]}" == "IPv4" && "${ip}" == *:* ]]; then
+    echo "Expected IPv4 cluster IP at index ${index}, found ${ip}" >&2
+    exit 1
+  fi
+  if [[ "${families[${index}]}" == "IPv6" && "${ip}" != *:* ]]; then
+    echo "Expected IPv6 cluster IP at index ${index}, found ${ip}" >&2
+    exit 1
+  fi
+done
+
+kubectl --namespace "${namespace}" delete pod "${probe_name}" --ignore-not-found
+trap 'kubectl --namespace "${namespace}" delete pod "${probe_name}" --ignore-not-found --wait=false' EXIT
+kubectl --namespace "${namespace}" run "${probe_name}" \
+  --image=curlimages/curl:8.15.0 \
+  --restart=Never \
+  --command -- sleep 600
+kubectl --namespace "${namespace}" wait --for=condition=Ready "pod/${probe_name}" --timeout=2m
+
+for ip in "${cluster_ips[@]}"; do
+  if [[ "${ip}" == *:* ]]; then
+    url="http://[${ip}]:8000/"
+  else
+    url="http://${ip}:8000/"
+  fi
+
+  # The root path may return any HTTP status; receiving a response is sufficient
+  # because this check verifies REST listener reachability through each Service IP.
+  reachable=false
+  for attempt in 1 2 3 4 5; do
+    if kubectl --namespace "${namespace}" exec "${probe_name}" -- \
+      curl --noproxy '*' --silent --show-error --connect-timeout 5 --max-time 10 --output /dev/null "${url}"; then
+      reachable=true
+      break
+    fi
+    if ((attempt < 5)); then
+      echo "REST probe to ${url} failed on attempt ${attempt}; retrying in 2 seconds" >&2
+      sleep 2
+    fi
+  done
+  if [[ "${reachable}" != "true" ]]; then
+    echo "REST probe to ${url} failed after 5 attempts" >&2
+    exit 1
+  fi
+done
+
+echo "Verified ${service_name} through IPv4 ${cluster_ips[0]} and IPv6 ${cluster_ips[1]}"

--- a/helm-charts/coherence-operator/chart_test.go
+++ b/helm-charts/coherence-operator/chart_test.go
@@ -9,12 +9,18 @@ package coherenceoperator
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/ghodss/yaml"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -34,6 +40,19 @@ type csvMetadata struct {
 	Spec struct {
 		MinKubeVersion string `json:"minKubeVersion"`
 	} `json:"spec"`
+}
+
+type chartValuesSchema struct {
+	Properties struct {
+		RestService struct {
+			Properties struct {
+				IPFamilies struct {
+					MaxItems    int  `json:"maxItems"`
+					UniqueItems bool `json:"uniqueItems"`
+				} `json:"ipFamilies"`
+			} `json:"properties"`
+		} `json:"restService"`
+	} `json:"properties"`
 }
 
 type kubernetesVersionFloor struct {
@@ -104,6 +123,232 @@ func TestKubernetesMinimumVersionsAreAligned(t *testing.T) {
 		t.Fatalf("Kubernetes minimum versions differ: Chart.yaml=%s, CSV=%s, Makefile=%s",
 			chartFloor.minorString(), csvFloor.minorString(), makefileFloor.minorString())
 	}
+}
+
+func TestRestServiceDefaultRendering(t *testing.T) {
+	service := renderRestService(t)
+	if service.Spec.IPFamilyPolicy != nil {
+		t.Fatalf("default ipFamilyPolicy = %q, want omitted", *service.Spec.IPFamilyPolicy)
+	}
+	if service.Spec.IPFamilies != nil {
+		t.Fatalf("default ipFamilies = %v, want omitted", service.Spec.IPFamilies)
+	}
+
+	if service.Namespace != "default" || service.Annotations != nil {
+		t.Fatalf("REST Service metadata changed unexpectedly: namespace=%q annotations=%v", service.Namespace, service.Annotations)
+	}
+	wantLabels := map[string]string{
+		"control-plane":                "coherence",
+		"app.kubernetes.io/name":       "coherence-operator",
+		"app.kubernetes.io/instance":   "coherence-operator-rest",
+		"app.kubernetes.io/version":    "${VERSION}",
+		"app.kubernetes.io/component":  "rest",
+		"app.kubernetes.io/part-of":    "coherence-operator",
+		"app.kubernetes.io/managed-by": "helm",
+	}
+	if !reflect.DeepEqual(service.Labels, wantLabels) {
+		t.Fatalf("REST Service labels = %v, want %v", service.Labels, wantLabels)
+	}
+	wantPorts := []corev1.ServicePort{{
+		Name:       "http-rest",
+		Port:       8000,
+		TargetPort: intstr.FromInt32(8000),
+	}}
+	if !reflect.DeepEqual(service.Spec.Ports, wantPorts) {
+		t.Fatalf("REST Service ports = %v, want %v", service.Spec.Ports, wantPorts)
+	}
+	wantSelector := map[string]string{
+		"app.kubernetes.io/name":      "coherence-operator",
+		"app.kubernetes.io/instance":  "coherence-operator-manager",
+		"app.kubernetes.io/version":   "${VERSION}",
+		"app.kubernetes.io/component": "manager",
+	}
+	if !reflect.DeepEqual(service.Spec.Selector, wantSelector) {
+		t.Fatalf("REST Service selector = %v, want %v", service.Spec.Selector, wantSelector)
+	}
+}
+
+func TestRestServiceFieldsRenderIndependently(t *testing.T) {
+	t.Run("policy only", func(t *testing.T) {
+		service := renderRestService(t, "--set", "restService.ipFamilyPolicy=PreferDualStack")
+		if service.Spec.IPFamilyPolicy == nil || *service.Spec.IPFamilyPolicy != corev1.IPFamilyPolicyPreferDualStack {
+			t.Fatalf("ipFamilyPolicy = %v, want PreferDualStack", service.Spec.IPFamilyPolicy)
+		}
+		if service.Spec.IPFamilies != nil {
+			t.Fatalf("ipFamilies = %v, want omitted", service.Spec.IPFamilies)
+		}
+	})
+
+	t.Run("families only", func(t *testing.T) {
+		service := renderRestService(t, "--set", "restService.ipFamilies={IPv6}")
+		if service.Spec.IPFamilyPolicy != nil {
+			t.Fatalf("ipFamilyPolicy = %v, want omitted", service.Spec.IPFamilyPolicy)
+		}
+		assertIPFamilies(t, service, corev1.IPv6Protocol)
+	})
+}
+
+func TestRestServiceIPFamilies(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		families []corev1.IPFamily
+	}{
+		{name: "IPv4 only", value: "{IPv4}", families: []corev1.IPFamily{corev1.IPv4Protocol}},
+		{name: "IPv6 only", value: "{IPv6}", families: []corev1.IPFamily{corev1.IPv6Protocol}},
+		{name: "IPv4 then IPv6", value: "{IPv4,IPv6}", families: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}},
+		{name: "IPv6 then IPv4", value: "{IPv6,IPv4}", families: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := renderRestService(t, "--set", "restService.ipFamilies="+tt.value)
+			assertIPFamilies(t, service, tt.families...)
+		})
+	}
+}
+
+func TestRestServiceIPFamilyPolicies(t *testing.T) {
+	policies := []corev1.IPFamilyPolicy{
+		corev1.IPFamilyPolicySingleStack,
+		corev1.IPFamilyPolicyPreferDualStack,
+		corev1.IPFamilyPolicyRequireDualStack,
+	}
+
+	for _, policy := range policies {
+		t.Run(string(policy), func(t *testing.T) {
+			service := renderRestService(t, "--set", "restService.ipFamilyPolicy="+string(policy))
+			if service.Spec.IPFamilyPolicy == nil || *service.Spec.IPFamilyPolicy != policy {
+				t.Fatalf("ipFamilyPolicy = %v, want %s", service.Spec.IPFamilyPolicy, policy)
+			}
+		})
+	}
+}
+
+func TestRestServiceSchemaValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "invalid policy", args: []string{"--set", "restService.ipFamilyPolicy=SometimesDualStack"}},
+		{name: "invalid family", args: []string{"--set", "restService.ipFamilies={IPv5}"}},
+		{name: "duplicate families", args: []string{"--set", "restService.ipFamilies={IPv4,IPv4}"}},
+		{name: "scalar families", args: []string{"--set", "restService.ipFamilies=IPv4"}},
+		{name: "more than two families", args: []string{"--set", "restService.ipFamilies={IPv4,IPv6,IPv4}"}},
+		{name: "unknown setting", args: []string{"--set", "restService.ipFamilyPolcy=PreferDualStack"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := helmTemplate(t, tt.args...)
+			if err == nil {
+				t.Fatal("helm template succeeded, want schema validation error")
+			}
+		})
+	}
+}
+
+func TestRestServiceSchemaListConstraints(t *testing.T) {
+	data, err := os.ReadFile("values.schema.json")
+	if err != nil {
+		t.Fatalf("failed to read Helm values schema: %v", err)
+	}
+
+	var schema chartValuesSchema
+	if err = yaml.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("failed to parse Helm values schema: %v", err)
+	}
+
+	ipFamilies := schema.Properties.RestService.Properties.IPFamilies
+	if ipFamilies.MaxItems != 2 {
+		t.Fatalf("ipFamilies maxItems = %d, want 2", ipFamilies.MaxItems)
+	}
+	if !ipFamilies.UniqueItems {
+		t.Fatal("ipFamilies uniqueItems = false, want true")
+	}
+}
+
+func renderRestService(t *testing.T, args ...string) *corev1.Service {
+	t.Helper()
+
+	output, err := helmTemplate(t, args...)
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, output)
+	}
+
+	for _, document := range strings.Split(output, "\n---") {
+		var resource struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		}
+		if err = yaml.Unmarshal([]byte(document), &resource); err != nil {
+			t.Fatalf("failed to parse rendered manifest: %v\n%s", err, document)
+		}
+		if resource.Kind == "Service" && resource.Metadata.Name == "coherence-operator-rest" {
+			service := &corev1.Service{}
+			if err = yaml.Unmarshal([]byte(document), service); err != nil {
+				t.Fatalf("failed to parse rendered REST Service: %v\n%s", err, document)
+			}
+			return service
+		}
+	}
+
+	t.Fatalf("rendered chart does not contain coherence-operator-rest Service:\n%s", output)
+	return nil
+}
+
+func assertIPFamilies(t *testing.T, service *corev1.Service, want ...corev1.IPFamily) {
+	t.Helper()
+
+	if len(service.Spec.IPFamilies) != len(want) {
+		t.Fatalf("ipFamilies = %v, want %v", service.Spec.IPFamilies, want)
+	}
+	for i := range want {
+		if service.Spec.IPFamilies[i] != want[i] {
+			t.Fatalf("ipFamilies = %v, want %v", service.Spec.IPFamilies, want)
+		}
+	}
+}
+
+func helmTemplate(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	chart := copyTestChart(t)
+	commandArgs := []string{"template", "operator", chart, "--show-only", "templates/deployment.yaml"}
+	commandArgs = append(commandArgs, args...)
+	cmd := exec.Command("helm", commandArgs...)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func copyTestChart(t *testing.T) string {
+	t.Helper()
+
+	destination := filepath.Join(t.TempDir(), "coherence-operator")
+	err := filepath.Walk(".", func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		target := filepath.Join(destination, path)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if path == "Chart.yaml" {
+			data = []byte(strings.ReplaceAll(string(data), "${VERSION}", "1.0.0"))
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+	if err != nil {
+		t.Fatalf("failed to prepare Helm chart for testing: %v", err)
+	}
+	return destination
 }
 
 func readChartMetadata(t *testing.T) chartMetadata {

--- a/helm-charts/coherence-operator/templates/deployment.yaml
+++ b/helm-charts/coherence-operator/templates/deployment.yaml
@@ -20,6 +20,13 @@ metadata:
 {{ toYaml .Values.globalAnnotations | indent 4 }}
 {{- end }}
 spec:
+{{- with .Values.restService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+{{- end }}
+{{- with .Values.restService.ipFamilies }}
+  ipFamilies:
+{{ toYaml . | indent 2 }}
+{{- end }}
   ports:
   - name: http-rest
     port: 8000

--- a/helm-charts/coherence-operator/values.schema.json
+++ b/helm-charts/coherence-operator/values.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "restService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": [
+            "SingleStack",
+            "PreferDualStack",
+            "RequireDualStack"
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "IPv4",
+              "IPv6"
+            ]
+          },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/helm-charts/coherence-operator/values.yaml
+++ b/helm-charts/coherence-operator/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020, 2024, Oracle Corporation and/or its affiliates.
+# Copyright 2020, 2026, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
@@ -14,6 +14,19 @@ defaultCoherenceImage:
   registry: "${COHERENCE_IMAGE_REGISTRY}"
   name: "${COHERENCE_IMAGE_NAME}"
   tag: "${COHERENCE_IMAGE_TAG}"
+
+# restService configures IP-family settings for the coherence-operator-rest Service.
+# Both settings are omitted by default, allowing Kubernetes to apply the cluster defaults.
+# Valid ipFamilyPolicy values are SingleStack, PreferDualStack, and RequireDualStack.
+# ipFamilies may contain IPv4, IPv6, or both values in the preferred order.
+#
+# For example:
+# restService:
+#   ipFamilyPolicy: PreferDualStack
+#   ipFamilies:
+#   - IPv4
+#   - IPv6
+restService: {}
 
 # watchNamespaces is the comma-delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.
@@ -238,4 +251,3 @@ leaderElectionDuration:
 # Normally this will be a number of seconds. For example, 30 seconds is "30s" and
 # there would not be any reason to have values in minutes or hours.
 leaderElectionRenewTimeout:
-

--- a/pkg/nettesting/server.go
+++ b/pkg/nettesting/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -8,12 +8,12 @@ package nettesting
 
 import (
 	"context"
-	"fmt"
 	"github.com/oracle/coherence-operator/pkg/operator"
 	"github.com/pkg/errors"
 	"net"
 	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"strconv"
 	"time"
 )
 
@@ -92,7 +92,7 @@ func (in simpleServer) Start(_ context.Context) error {
 	mux := http.NewServeMux()
 	mux.Handle("/", handler{fn: in.requestHandler})
 
-	address := fmt.Sprintf("%s:%d", operator.GetRestHost(), in.port)
+	address := net.JoinHostPort(operator.GetRestHost(), strconv.Itoa(in.port))
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return errors.Wrap(err, "failed to start server")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	DefaultRestHost       = "0.0.0.0"
+	DefaultRestHost       = ""
 	DefaultRestPort int32 = 8000
 
 	DefaultMutatingWebhookName   = "coherence-operator-mutating-webhook-configuration"
@@ -288,7 +288,11 @@ func GetDefaultOperatorImage() string {
 }
 
 func GetRestHost() string {
-	return GetViper().GetString(FlagRestHost)
+	host := GetViper().GetString(FlagRestHost)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	return host
 }
 
 func GetRestPort() int32 {

--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -136,19 +136,22 @@ func (s *server) Start(context.Context) error {
 	mux.Handle("/rack/", handler{fn: s.getRackLabelForNode})
 	mux.Handle("/status/", handler{fn: s.getCoherenceStatus})
 
-	address := fmt.Sprintf("%s:%d", operator.GetRestHost(), operator.GetRestPort())
+	address := net.JoinHostPort(operator.GetRestHost(), strconv.Itoa(int(operator.GetRestPort())))
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return errors.Wrap(err, "failed to start REST server")
 	}
 
 	s.listener = listener
+	s.httpServer = &http.Server{Handler: mux}
 
 	close(s.running)
 
 	go func() {
 		log.Info("Serving REST requests", "listenAddress", s.listener.Addr().String())
-		panic(http.Serve(s.listener, mux))
+		if serveErr := s.httpServer.Serve(s.listener); serveErr != nil && serveErr != http.ErrServerClosed {
+			log.Error(serveErr, "REST server stopped unexpectedly")
+		}
 	}()
 	return nil
 }
@@ -163,6 +166,9 @@ func (s *server) GetPort() int32 {
 }
 
 func (s *server) Close() error {
+	if s.httpServer == nil {
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	s.httpServer.SetKeepAlivesEnabled(false)
@@ -180,15 +186,17 @@ func (s *server) GetHostAndPort() string {
 	case serviceName != "":
 		// use the service name if it was specifically set
 		service = serviceName
-	case restHost != "0.0.0.0":
+	case !isWildcardHost(restHost):
 		// if no service name was set but REST is bound to a specific address then use that
 		service = restHost
 	default:
-		// REST is bound to 0.0.0.0 so use any of our local addresses.
+		// REST is bound to a wildcard address so use any of our local addresses.
 		// This does not guarantee we're reachable but would be OK in local testing
 		ip, err := onet.GetLocalAddress()
 		if err == nil && ip != nil {
-			service = fmt.Sprint(ip.String())
+			service = ip.String()
+		} else {
+			service = "localhost"
 		}
 	}
 
@@ -204,7 +212,14 @@ func (s *server) GetHostAndPort() string {
 		port = s.GetPort()
 	}
 
-	return fmt.Sprintf("%s:%d", service, port)
+	return net.JoinHostPort(service, strconv.Itoa(int(port)))
+}
+
+func isWildcardHost(host string) bool {
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	ip := net.ParseIP(host)
+	return host == "" || ip != nil && ip.IsUnspecified()
 }
 
 // getSiteLabelForNode is a GET request that returns the node label on a k8s node to use for a Coherence site value.

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package rest
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/oracle/coherence-operator/pkg/operator"
+	"github.com/spf13/viper"
+)
+
+func TestDefaultWildcardAcceptsLoopbackConnections(t *testing.T) {
+	setRestConfiguration(t, operator.DefaultRestHost, 0, "", -1)
+	s := startTestServer(t)
+	port := strconv.Itoa(int(s.GetPort()))
+
+	assertCanConnect(t, net.JoinHostPort("127.0.0.1", port))
+	if supportsIPv6Loopback() {
+		assertCanConnect(t, net.JoinHostPort("::1", port))
+	}
+}
+
+func TestExplicitRestHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		dialHost string
+		network  string
+	}{
+		{name: "IPv4", host: "127.0.0.1", dialHost: "127.0.0.1", network: "tcp4"},
+		{name: "IPv6", host: "::1", dialHost: "::1", network: "tcp6"},
+		{name: "bracketed IPv6", host: "[::1]", dialHost: "::1", network: "tcp6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.network == "tcp6" && !supportsIPv6Loopback() {
+				t.Skip("IPv6 loopback is not available")
+			}
+
+			setRestConfiguration(t, tt.host, 0, "", -1)
+			s := startTestServer(t)
+			assertCanConnect(t, net.JoinHostPort(tt.dialHost, strconv.Itoa(int(s.GetPort()))))
+		})
+	}
+}
+
+func TestGetHostAndPort(t *testing.T) {
+	t.Run("explicit IPv4", func(t *testing.T) {
+		setRestConfiguration(t, "127.0.0.1", 8001, "", -1)
+		s := &server{}
+		if actual := s.GetHostAndPort(); actual != "127.0.0.1:8001" {
+			t.Fatalf("GetHostAndPort() = %q, want %q", actual, "127.0.0.1:8001")
+		}
+	})
+
+	t.Run("explicit IPv6", func(t *testing.T) {
+		setRestConfiguration(t, "::1", 8002, "", -1)
+		s := &server{}
+		if actual := s.GetHostAndPort(); actual != "[::1]:8002" {
+			t.Fatalf("GetHostAndPort() = %q, want %q", actual, "[::1]:8002")
+		}
+	})
+
+	t.Run("bracketed explicit IPv6", func(t *testing.T) {
+		setRestConfiguration(t, "[::1]", 8003, "", -1)
+		s := &server{}
+		if actual := s.GetHostAndPort(); actual != "[::1]:8003" {
+			t.Fatalf("GetHostAndPort() = %q, want %q", actual, "[::1]:8003")
+		}
+	})
+
+	t.Run("service", func(t *testing.T) {
+		setRestConfiguration(t, operator.DefaultRestHost, 8000, "operator-rest", 9000)
+		operator.GetViper().Set(operator.FlagOperatorNamespace, "testing")
+		s := &server{}
+		if actual := s.GetHostAndPort(); actual != "operator-rest.testing.svc:9000" {
+			t.Fatalf("GetHostAndPort() = %q, want %q", actual, "operator-rest.testing.svc:9000")
+		}
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		setRestConfiguration(t, operator.DefaultRestHost, 0, "", -1)
+		s := startTestServer(t)
+		actual := s.GetHostAndPort()
+		host, port, err := net.SplitHostPort(actual)
+		if err != nil {
+			t.Fatalf("GetHostAndPort() returned invalid address %q: %v", actual, err)
+		}
+		if host == "" || isWildcardHost(host) {
+			t.Fatalf("GetHostAndPort() returned unusable wildcard host %q", host)
+		}
+		if port != strconv.Itoa(int(s.GetPort())) {
+			t.Fatalf("GetHostAndPort() port = %q, want %d", port, s.GetPort())
+		}
+	})
+}
+
+func startTestServer(t *testing.T) *server {
+	t.Helper()
+
+	s := &server{
+		running: make(chan struct{}),
+		endpoints: map[string]func(http.ResponseWriter, *http.Request){
+			"/": func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+		},
+	}
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start REST server: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Errorf("failed to close REST server: %v", err)
+		}
+	})
+	return s
+}
+
+func setRestConfiguration(t *testing.T, host string, port int32, serviceName string, servicePort int32) {
+	t.Helper()
+
+	previous := operator.GetViper()
+	v := viper.New()
+	v.Set(operator.FlagRestHost, host)
+	v.Set(operator.FlagRestPort, port)
+	v.Set(operator.FlagServiceName, serviceName)
+	v.Set(operator.FlagServicePort, servicePort)
+	operator.SetViper(v)
+	t.Cleanup(func() {
+		operator.SetViper(previous)
+	})
+}
+
+func assertCanConnect(t *testing.T, address string) {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect to %s: %v", address, err)
+	}
+	if err = conn.Close(); err != nil {
+		t.Fatalf("failed to close connection to %s: %v", address, err)
+	}
+}
+
+func supportsIPv6Loopback() bool {
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
+}


### PR DESCRIPTION
  ## Summary

  - Add Helm values for configuring ipFamilyPolicy and ipFamilies on the coherence-operator-rest Service.
  - Preserve existing Kubernetes defaulting when the new values are omitted.
  - Bind the REST listener to the dual-stack wildcard by default while retaining explicit --rest-host support.
  - Add schema validation, documentation, Helm tests, REST listener tests, and a dual-stack KinD workflow covering single-stack and dual-stack configurations.
  - Update GitHub Actions dependencies and the custom ORAS action runtime to Node.js 24.

  ## Test coverage

  - Helm rendering and schema-validation tests for valid and invalid IP-family settings.
  - REST server tests for wildcard, IPv4, IPv6, and bracketed IPv6 addresses.
  - KinD acceptance tests covering:
      - Kubernetes defaults
      - IPv4 and IPv6 single-stack Services
      - PreferDualStack and RequireDualStack
      - Both IPv4-first and IPv6-first family orders
      - ClusterIPs, EndpointSlices, Pod addresses, and REST connectivity
