### PR TITLE
Fix finalization with IPv6 suspend probes

### DIFF
--- a/.github/workflows/dual-stack.yaml
+++ b/.github/workflows/dual-stack.yaml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Verify IPv6 suspend finalization
         run: |
-          make run-e2e-test \
+          RUN_IPV6_FINALIZER_TEST=true make run-e2e-test \
             OPERATOR_NAMESPACE=operator-test \
             GO_TEST_FLAGS_E2E='-run=^TestSuspendServicesWithIPv6PodIP$ -count=1'
 

--- a/.github/workflows/dual-stack.yaml
+++ b/.github/workflows/dual-stack.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
-name: Operator REST Dual Stack
+name: Coherence Operator Dual Stack
 
 on:
   workflow_dispatch:
@@ -25,7 +25,7 @@ on:
 jobs:
   dual-stack:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
@@ -59,11 +59,11 @@ jobs:
       - name: Start dual-stack KinD cluster
         run: make kind-dual
 
-      - name: Build operator image and Helm chart
-        run: make build-operator helm-chart
+      - name: Build operator image, Helm chart, and basic test image
+        run: make build-operator helm-chart build-basic-test-image
 
-      - name: Load operator image
-        run: make kind-load-operator
+      - name: Load operator and basic test images
+        run: make kind-load-operator kind-load-basic-test-image
 
       - name: Verify REST Service IP-family matrix
         run: |
@@ -80,6 +80,7 @@ jobs:
             local expected_families_csv="$3"
             local configured_policy="$4"
             local configured_families="$5"
+            local keep_release="${6:-false}"
             local expected_families=()
             local helm_args=(--set replicas=1)
 
@@ -102,26 +103,95 @@ jobs:
             hack/kind/verify-operator-rest-dual-stack.sh \
               operator-test coherence-operator-rest "${expected_policy}" "${expected_families[@]}"
 
-            helm uninstall coherence-operator --namespace operator-test --wait --timeout 5m
-            kubectl --namespace operator-test wait --for=delete \
-              service/coherence-operator-rest --timeout=2m
+            if [[ "${keep_release}" == false ]]; then
+              helm uninstall coherence-operator --namespace operator-test --wait --timeout 5m
+              kubectl --namespace operator-test wait --for=delete \
+                service/coherence-operator-rest --timeout=2m
+            fi
           }
 
-          verify_scenario default SingleStack IPv4 "" ""
+          verify_scenario default SingleStack IPv6 "" ""
           verify_scenario single-stack-ipv4 SingleStack IPv4 SingleStack IPv4
           verify_scenario single-stack-ipv6 SingleStack IPv6 SingleStack IPv6
           verify_scenario prefer-dual-stack-ipv4-first PreferDualStack IPv4,IPv6 PreferDualStack IPv4,IPv6
           verify_scenario prefer-dual-stack-ipv6-first PreferDualStack IPv6,IPv4 PreferDualStack IPv6,IPv4
           verify_scenario require-dual-stack-ipv4-first RequireDualStack IPv4,IPv6 RequireDualStack IPv4,IPv6
-          verify_scenario require-dual-stack-ipv6-first RequireDualStack IPv6,IPv4 RequireDualStack IPv6,IPv4
+          verify_scenario require-dual-stack-ipv6-first RequireDualStack IPv6,IPv4 RequireDualStack IPv6,IPv4 true
+
+      - name: Verify IPv6 suspend finalization
+        run: |
+          make run-e2e-test \
+            OPERATOR_NAMESPACE=operator-test \
+            GO_TEST_FLAGS_E2E='-run=^TestSuspendServicesWithIPv6PodIP$ -count=1'
 
       - name: Collect diagnostics
         if: ${{ failure() || cancelled() }}
         run: |
-          kubectl get all --all-namespaces -o wide
-          kubectl --namespace operator-test get service coherence-operator-rest -o yaml || true
-          kubectl --namespace operator-test get endpointslices \
-            --selector kubernetes.io/service-name=coherence-operator-rest -o yaml || true
+          diagnostics=build/_output/test-logs/dual-stack-diagnostics
+          mkdir -p "${diagnostics}"
+
+          kubectl get all --all-namespaces -o wide \
+            | tee "${diagnostics}/all-resources.txt" || true
+          kubectl --namespace operator-test get coherence.coherence.oracle.com -o yaml \
+            > "${diagnostics}/coherence.yaml" || true
+          kubectl get storageclasses -o yaml \
+            > "${diagnostics}/storageclasses.yaml" || true
+          kubectl --namespace operator-test get persistentvolumeclaims -o yaml \
+            > "${diagnostics}/persistentvolumeclaims.yaml" || true
+          kubectl --namespace operator-test get statefulsets -o yaml \
+            > "${diagnostics}/statefulsets.yaml" || true
+          kubectl --namespace operator-test get pods -o yaml \
+            > "${diagnostics}/pods.yaml" || true
           kubectl --namespace operator-test get pods \
-            -o custom-columns='NAME:.metadata.name,POD_IPS:.status.podIPs[*].ip,NODE:.spec.nodeName' || true
-          kubectl --namespace operator-test logs deployment/coherence-operator --all-pods=true || true
+            -o custom-columns='NAME:.metadata.name,PRIMARY_IP:.status.podIP,POD_IPS:.status.podIPs[*].ip,NODE:.spec.nodeName' \
+            | tee "${diagnostics}/pod-addresses.txt" || true
+          kubectl --namespace operator-test get service coherence-operator-rest -o yaml \
+            > "${diagnostics}/operator-rest-service.yaml" || true
+          kubectl --namespace operator-test get endpointslices \
+            --selector kubernetes.io/service-name=coherence-operator-rest -o yaml \
+            > "${diagnostics}/operator-rest-endpointslices.yaml" || true
+          kubectl --namespace operator-test get events \
+            --sort-by=.metadata.creationTimestamp -o wide \
+            | tee "${diagnostics}/events.txt" || true
+          kubectl --namespace operator-test logs deployment/coherence-operator \
+            --all-pods=true --all-containers=true --prefix \
+            > "${diagnostics}/operator.log" || true
+
+          while read -r pod; do
+            if [[ -n "${pod}" ]]; then
+              pod_name="${pod#pod/}"
+              kubectl --namespace operator-test logs "${pod}" \
+                --all-containers=true --prefix \
+                > "${diagnostics}/${pod_name}.log" || true
+            fi
+          done < <(kubectl --namespace operator-test get pods \
+            --selector coherenceComponent=coherencePod -o name 2>/dev/null)
+
+      - name: Clean up dual-stack resources
+        if: ${{ always() }}
+        run: |
+          for resource in $(kubectl --namespace operator-test get \
+            coherence.coherence.oracle.com -o name 2>/dev/null); do
+            kubectl --namespace operator-test patch "${resource}" --type=merge \
+              --patch '{"metadata":{"finalizers":[]}}' || true
+            kubectl --namespace operator-test delete "${resource}" \
+              --ignore-not-found --wait=false || true
+          done
+          kubectl --namespace operator-test delete pod \
+            coherence-operator-rest-dual-stack-probe --ignore-not-found --wait=false || true
+          kubectl --namespace operator-test delete statefulsets \
+            --selector coherenceComponent=coherence --ignore-not-found --wait=false || true
+          kubectl --namespace operator-test delete pods \
+            --selector coherenceComponent=coherencePod --ignore-not-found --wait=false || true
+          kubectl --namespace operator-test delete persistentvolumeclaims \
+            --selector coherenceComponent=coherence-volume --ignore-not-found --wait=false || true
+          helm uninstall coherence-operator --namespace operator-test \
+            --wait --timeout 5m || true
+
+      - name: Upload dual-stack test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: dual-stack-test-logs
+          path: build/_output/test-logs
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------------------------------------------------
-# Copyright (c) 2019, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2019, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 #
@@ -2326,6 +2326,10 @@ kind-load-coherence: kind-install  ## Load the Coherence image into the KinD clu
 .PHONY: kind-load-operator
 kind-load-operator: kind-install  ## Load the Operator images into the KinD cluster
 	$(KIND) load docker-image --name $(KIND_CLUSTER) $(OPERATOR_IMAGE) || true
+
+.PHONY: kind-load-basic-test-image
+kind-load-basic-test-image: kind-install  ## Load the basic Operator test image into the KinD cluster
+	$(KIND) load docker-image --name $(KIND_CLUSTER) $(TEST_APPLICATION_IMAGE)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Load compatibility images into Kind

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/controllers/coherence_controller.go
+++ b/controllers/coherence_controller.go
@@ -78,6 +78,7 @@ var _ reconcile.Reconciler = &CoherenceReconciler{}
 
 // +kubebuilder:rbac:groups=coherence.oracle.com,resources=coherence;coherencejob;coherence/finalizers;coherencejob/finalizers;coherence/status;coherencejob/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods;pods/exec;services;endpoints;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/reconciler/base_controller.go
+++ b/controllers/reconciler/base_controller.go
@@ -738,7 +738,7 @@ func (in *ReconcileSecondaryResource) ReconcileAllResourceOfKind(ctx context.Con
 					return reconcile.Result{}, errors.Wrapf(err, "Failed to delete resource %v/%s", in.Kind, del.Name)
 				}
 				if err == nil {
-					in.GetEventRecorder().Eventf(resource, nil, corev1.EventTypeNormal, EventReasonDeleted, "", fmt.Sprintf("Deleted resource after update to Coherence resource %s", deployment.GetName()))
+					in.GetEventRecorder().Eventf(resource, nil, corev1.EventTypeNormal, EventReasonDeleted, "DeleteResource", fmt.Sprintf("Deleted resource after update to Coherence resource %s", deployment.GetName()))
 				}
 			}
 		}

--- a/controllers/statefulset/statefulset_controller.go
+++ b/controllers/statefulset/statefulset_controller.go
@@ -125,7 +125,7 @@ func (in *ReconcileStatefulSet) ReconcileAllResourceOfKind(ctx context.Context, 
 	stsCurrent, stsExists, err := in.MaybeFindStatefulSet(ctx, request.Namespace, request.Name)
 	if err != nil {
 		logger.Info("Finished reconciling StatefulSet. Error getting StatefulSet", "error", err.Error())
-		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonReconciling, "",
+		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonReconciling, "ReconcileStatefulSet",
 			"error getting StatefulSet %s, %s", request.Name, err.Error())
 		return result, errors.Wrapf(err, "getting StatefulSet %s/%s", request.Namespace, request.Name)
 	}
@@ -140,7 +140,7 @@ func (in *ReconcileStatefulSet) ReconcileAllResourceOfKind(ctx context.Context, 
 		// find the owning Coherence resource
 		if deployment, err = in.FindOwningCoherenceResource(ctx, stsCurrent); err != nil {
 			logger.Info("Finished reconciling StatefulSet. Error finding parent Coherence resource", "error", err.Error())
-			in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonReconciling, "",
+			in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonReconciling, "ReconcileStatefulSet",
 				"finding parent Coherence resource %s, %s", request.Name, err.Error())
 			return reconcile.Result{}, err
 		}
@@ -156,7 +156,7 @@ func (in *ReconcileStatefulSet) ReconcileAllResourceOfKind(ctx context.Context, 
 				// If the Coherence resource did not exist then service suspension already happened
 				// when the Coherence resource was deleted.
 				logger.Info("Scaling down to zero")
-				in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "",
+				in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "ScaleStatefulSet",
 					"scaling statefuleset %s down to zero", request.Name)
 				err = in.UpdateDeploymentStatusActionsState(ctx, request.NamespacedName, false)
 				// TODO: what to do with error?
@@ -165,21 +165,21 @@ func (in *ReconcileStatefulSet) ReconcileAllResourceOfKind(ctx context.Context, 
 				}
 				stsSpec, _ := deployment.GetStatefulSetSpec()
 				if stsSpec.IsSuspendServicesOnShutdown() {
-					in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "",
+					in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "SuspendServices",
 						"suspending Coherence services in statefuleset %s", request.Name)
 					// we are scaling down to zero and suspend services flag is true, so suspend services
 					suspended := in.suspendServices(ctx, deployment, stsCurrent)
 					switch suspended {
 					case probe.ServiceSuspendFailed:
-						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonScaling, "",
+						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonScaling, "SuspendServices",
 							"failed suspending Coherence services in statefuleset %s", request.Name)
 						return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("failed to suspend services prior to scaling down to zero")
 					case probe.ServiceSuspendSkipped:
 						logger.Info("skipping suspension of Coherence services prior to deletion of StatefulSet")
-						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "",
+						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "SuspendServices",
 							"skipped suspended Coherence services in statefuleset %s", request.Name)
 					case probe.ServiceSuspendSuccessful:
-						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "",
+						in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonScaling, "SuspendServices",
 							"suspended Coherence services in statefuleset %s", request.Name)
 					}
 				}
@@ -287,7 +287,7 @@ func (in *ReconcileStatefulSet) createStatefulSet(ctx context.Context, deploymen
 
 	if !ok {
 		// start quorum not met, send event and update deployment status
-		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, "Waiting", "", reason)
+		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, "Waiting", "StartQuorum", reason)
 		_ = in.UpdateCoherenceStatusCondition(ctx, deployment.GetNamespacedName(), coh.Condition{
 			Type:    coh.ConditionTypeWaiting,
 			Status:  corev1.ConditionTrue,
@@ -307,7 +307,7 @@ func (in *ReconcileStatefulSet) createStatefulSet(ctx context.Context, deploymen
 
 		// send a successful creation event
 		msg := fmt.Sprintf(CreateMessage, deployment.GetName())
-		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonCreated, "", msg)
+		in.GetEventRecorder().Eventf(deployment, nil, corev1.EventTypeNormal, reconciler.EventReasonCreated, "CreateStatefulSet", msg)
 	}
 
 	logger.Info("Created statefulSet")
@@ -444,7 +444,7 @@ func (in *ReconcileStatefulSet) maybePatchStatefulSet(ctx context.Context, deplo
 	if len(errorList) > 0 {
 		msg := fmt.Sprintf("upddates to the statefuleset would have been invalid, the update will not be re-queued: %v", errorList)
 		evts := in.GetEventRecorder()
-		evts.Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonUpdated, "", msg)
+		evts.Eventf(deployment, nil, corev1.EventTypeWarning, reconciler.EventReasonUpdated, "ValidateStatefulSetUpdate", msg)
 		return reconcile.Result{}, errors.New(msg)
 	}
 
@@ -728,13 +728,13 @@ func (in *ReconcileStatefulSet) parallelScale(ctx context.Context, deployment co
 	if err != nil {
 		// send a failed scale event
 		msg := fmt.Sprintf("failed to scale StatefulSet %s from %d to %d", sts.Name, in.getReplicas(sts), replicas)
-		evts.Eventf(deployment, nil, corev1.EventTypeNormal, EventReasonScale, "", msg)
+		evts.Eventf(deployment, nil, corev1.EventTypeNormal, EventReasonScale, "ScaleStatefulSet", msg)
 		return reconcile.Result{}, errors.Wrap(err, msg)
 	}
 
 	// send a successful scale event
 	msg := fmt.Sprintf("scaled StatefulSet %s from %d to %d", sts.Name, in.getReplicas(sts), replicas)
-	evts.Eventf(deployment, nil, corev1.EventTypeNormal, EventReasonScale, "", msg)
+	evts.Eventf(deployment, nil, corev1.EventTypeNormal, EventReasonScale, "ScaleStatefulSet", msg)
 
 	if scaleDown {
 		return reconcile.Result{RequeueAfter: time.Minute}, nil

--- a/hack/kind/kind-config-dual.yaml
+++ b/hack/kind/kind-config-dual.yaml
@@ -2,6 +2,8 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: dual
+  podSubnet: "fd00:10:244::/56,10.244.0.0/16"
+  serviceSubnet: "fd00:10:96::/112,10.96.0.0/16"
 nodes:
   - role: control-plane
   - role: worker

--- a/helm-charts/coherence-operator/templates/rbac.yaml
+++ b/helm-charts/coherence-operator/templates/rbac.yaml
@@ -234,6 +234,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -7,6 +7,8 @@
 package events
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	events2 "k8s.io/client-go/tools/events"
@@ -38,7 +40,7 @@ func NewOwnedEventRecorder(owner runtime.Object, recorder events2.EventRecorder)
 // The resulting event will be created in the same namespace as the reference object.
 func (in *OwnedEventRecorder) Event(eventType, reason, message string) {
 	if in != nil && in.owner != nil && in.recorder != nil {
-		in.recorder.Eventf(in.owner, nil, eventType, reason, "Operator", message)
+		in.recorder.Eventf(in.owner, nil, eventType, reason, "Operator", "%s", message)
 	}
 }
 
@@ -54,9 +56,7 @@ func (in *OwnedEventRecorder) Info(reason, message string) {
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func (in *OwnedEventRecorder) Eventf(eventType, reason, messageFmt string, args ...interface{}) {
-	if in != nil && in.owner != nil && in.recorder != nil {
-		in.recorder.Eventf(in.owner, nil, eventType, reason, "", messageFmt, args...)
-	}
+	in.Event(eventType, reason, fmt.Sprintf(messageFmt, args...))
 }
 
 // Warnf is just like Eventf, and sends a Warning event.

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package events
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type recordedEvent struct {
+	regarding runtime.Object
+	related   runtime.Object
+	eventType string
+	reason    string
+	action    string
+	note      string
+}
+
+type actionRecorder struct {
+	event recordedEvent
+}
+
+func (in *actionRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventType, reason, action, note string, args ...interface{}) {
+	in.event = recordedEvent{
+		regarding: regarding,
+		related:   related,
+		eventType: eventType,
+		reason:    reason,
+		action:    action,
+		note:      fmt.Sprintf(note, args...),
+	}
+}
+
+func TestOwnedEventRecorderUsesNonEmptyAction(t *testing.T) {
+	owner := &corev1.Pod{}
+
+	tests := []struct {
+		name      string
+		record    func(*OwnedEventRecorder)
+		eventType string
+		reason    string
+		note      string
+	}{
+		{
+			name: "event",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Event(corev1.EventTypeNormal, "Created", "created resource")
+			},
+			eventType: corev1.EventTypeNormal,
+			reason:    "Created",
+			note:      "created resource",
+		},
+		{
+			name: "event with literal percent",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Event(corev1.EventTypeNormal, "Progressing", "progress 100%")
+			},
+			eventType: corev1.EventTypeNormal,
+			reason:    "Progressing",
+			note:      "progress 100%",
+		},
+		{
+			name: "formatted event",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Eventf(corev1.EventTypeWarning, "Failed", "failed resource %s", "test")
+			},
+			eventType: corev1.EventTypeWarning,
+			reason:    "Failed",
+			note:      "failed resource test",
+		},
+		{
+			name: "formatted event with percent verb",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Eventf(corev1.EventTypeNormal, "Progressing", "progress %d%%", 100)
+			},
+			eventType: corev1.EventTypeNormal,
+			reason:    "Progressing",
+			note:      "progress 100%",
+		},
+		{
+			name: "formatted event with percent in argument",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Eventf(corev1.EventTypeWarning, "Failed", "failed: %s", "disk 90%")
+			},
+			eventType: corev1.EventTypeWarning,
+			reason:    "Failed",
+			note:      "failed: disk 90%",
+		},
+		{
+			name: "formatted info",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Infof("ServiceSuspended", "suspended StatefulSet %s", "test")
+			},
+			eventType: corev1.EventTypeNormal,
+			reason:    "ServiceSuspended",
+			note:      "suspended StatefulSet test",
+		},
+		{
+			name: "formatted warning",
+			record: func(recorder *OwnedEventRecorder) {
+				recorder.Warnf("ServiceSuspendFailed", "failed StatefulSet %s", "test")
+			},
+			eventType: corev1.EventTypeWarning,
+			reason:    "ServiceSuspendFailed",
+			note:      "failed StatefulSet test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &actionRecorder{}
+			recorder := NewOwnedEventRecorder(owner, target)
+
+			tt.record(&recorder)
+
+			if target.event.regarding != owner {
+				t.Fatalf("regarding = %v, want owner %v", target.event.regarding, owner)
+			}
+			if target.event.related != nil {
+				t.Fatalf("related = %v, want nil", target.event.related)
+			}
+			if target.event.eventType != tt.eventType {
+				t.Errorf("event type = %q, want %q", target.event.eventType, tt.eventType)
+			}
+			if target.event.reason != tt.reason {
+				t.Errorf("reason = %q, want %q", target.event.reason, tt.reason)
+			}
+			if target.event.action != "Operator" {
+				t.Errorf("action = %q, want %q", target.event.action, "Operator")
+			}
+			if target.event.note != tt.note {
+				t.Errorf("note = %q, want %q", target.event.note, tt.note)
+			}
+		})
+	}
+}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
+	"net"
 	"net/http"
 	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -151,10 +152,10 @@ func (in *CoherenceProbe) SuspendServices(ctx context.Context, deployment coh.Co
 
 	log.Info("Suspending Coherence services in StatefulSet "+sts.Name, "Namespace", ns, "Name", name)
 	if in.ExecuteProbe(ctx, sts, deployment.GetWkaServiceName(), stsSpec.GetSuspendProbe()) {
-		in.EventRecorder.Warnf("ServiceSuspendFailed", "failed to suspend Coherence services in StatefulSet %s", sts.Name)
+		in.EventRecorder.Infof("ServiceSuspended", "suspended Coherence services in StatefulSet %s", sts.Name)
 		return ServiceSuspendSuccessful
 	}
-	in.EventRecorder.Infof("ServiceSuspended", "suspended Coherence services in StatefulSet %s", sts.Name)
+	in.EventRecorder.Warnf("ServiceSuspendFailed", "failed to suspend Coherence services in StatefulSet %s", sts.Name)
 	return ServiceSuspendFailed
 }
 
@@ -289,7 +290,6 @@ func (in *CoherenceProbe) ProbeUsingHTTP(pod corev1.Pod, svc string, handler *co
 		scheme   corev1.URIScheme
 		hostOrIP string
 		port     int
-		path     string
 	)
 
 	action := handler.HTTPGet
@@ -311,13 +311,7 @@ func (in *CoherenceProbe) ProbeUsingHTTP(pod corev1.Pod, svc string, handler *co
 		return false, err
 	}
 
-	if strings.HasPrefix(action.Path, "/") {
-		path = action.Path[1:]
-	} else {
-		path = action.Path
-	}
-
-	u, err := url.Parse(fmt.Sprintf("%s://%s:%d/%s", scheme, hostOrIP, port, path))
+	u, err := buildHTTPProbeURL(scheme, hostOrIP, port, action.Path)
 	if err != nil {
 		return false, err
 	}
@@ -342,6 +336,12 @@ func (in *CoherenceProbe) ProbeUsingHTTP(pod corev1.Pod, svc string, handler *co
 	log.Info("Executed HTTP Probe", "URL", u, "Result", fmt.Sprintf("%v", result), "Msg", s, "Error", err)
 
 	return result == Success, err
+}
+
+func buildHTTPProbeURL(scheme corev1.URIScheme, host string, port int, path string) (*url.URL, error) {
+	hostAndPort := net.JoinHostPort(host, strconv.Itoa(port))
+	path = strings.TrimPrefix(path, "/")
+	return url.Parse(fmt.Sprintf("%s://%s/%s", scheme, hostAndPort, path))
 }
 
 func (in *CoherenceProbe) ProbeUsingTCP(pod corev1.Pod, handler *coh.Probe) (bool, error) {

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package probe
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	coh "github.com/oracle/coherence-operator/api/v1"
+	cohevents "github.com/oracle/coherence-operator/pkg/events"
+	"github.com/oracle/coherence-operator/pkg/operator"
+	"github.com/spf13/viper"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildHTTPProbeURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme corev1.URIScheme
+		host   string
+		port   int
+		path   string
+		want   string
+	}{
+		{
+			name:   "IPv4 address",
+			scheme: corev1.URISchemeHTTP,
+			host:   "10.0.0.8",
+			port:   6676,
+			path:   "/suspend",
+			want:   "http://10.0.0.8:6676/suspend",
+		},
+		{
+			name:   "DNS hostname with HTTPS",
+			scheme: corev1.URISchemeHTTPS,
+			host:   "storage-0.storage.test.svc",
+			port:   6676,
+			path:   "ready",
+			want:   "https://storage-0.storage.test.svc:6676/ready",
+		},
+		{
+			name:   "IPv6 address",
+			scheme: corev1.URISchemeHTTP,
+			host:   "fd02:0:0:6::8e35",
+			port:   6676,
+			path:   "/suspend",
+			want:   "http://[fd02:0:0:6::8e35]:6676/suspend",
+		},
+		{
+			name:   "path query",
+			scheme: corev1.URISchemeHTTP,
+			host:   "127.0.0.1",
+			port:   8080,
+			path:   "/health?verbose=true",
+			want:   "http://127.0.0.1:8080/health?verbose=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := buildHTTPProbeURL(tt.scheme, tt.host, tt.port, tt.path)
+			if err != nil {
+				t.Fatalf("buildHTTPProbeURL() returned an error: %v", err)
+			}
+			if got := u.String(); got != tt.want {
+				t.Fatalf("buildHTTPProbeURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSuspendServicesReportsResult(t *testing.T) {
+	originalSkipServiceSuspend := viper.GetBool(operator.FlagSkipServiceSuspend)
+	viper.Set(operator.FlagSkipServiceSuspend, false)
+	t.Cleanup(func() {
+		viper.Set(operator.FlagSkipServiceSuspend, originalSkipServiceSuspend)
+	})
+
+	tests := []struct {
+		name         string
+		responseCode int
+		wantStatus   ServiceSuspendStatus
+		wantEvent    string
+		rejectEvent  string
+	}{
+		{
+			name:         "successful suspend",
+			responseCode: http.StatusOK,
+			wantStatus:   ServiceSuspendSuccessful,
+			wantEvent:    "Normal ServiceSuspended suspended Coherence services in StatefulSet test-deployment",
+			rejectEvent:  "ServiceSuspendFailed",
+		},
+		{
+			name:         "failed suspend",
+			responseCode: http.StatusInternalServerError,
+			wantStatus:   ServiceSuspendFailed,
+			wantEvent:    "Warning ServiceSuspendFailed failed to suspend Coherence services in StatefulSet test-deployment",
+			rejectEvent:  "ServiceSuspended",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.responseCode)
+			}))
+			defer server.Close()
+
+			host, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+			if err != nil {
+				t.Fatalf("failed to split test server address: %v", err)
+			}
+
+			labels := map[string]string{
+				"app":                        "test-deployment",
+				operator.LabelTestHostName:   host,
+				operator.LabelTestHealthPort: port,
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment-0",
+					Namespace: "test-namespace",
+					Labels:    labels,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test-deployment"},
+					},
+				},
+			}
+			deployment := &coh.Coherence{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+			}
+
+			recorder := events.NewFakeRecorder(10)
+			coherenceProbe := CoherenceProbe{
+				Client:        fake.NewClientBuilder().WithObjects(pod).Build(),
+				EventRecorder: cohevents.NewOwnedEventRecorder(deployment, recorder),
+			}
+
+			if got := coherenceProbe.SuspendServices(context.Background(), deployment, sts); got != tt.wantStatus {
+				t.Fatalf("SuspendServices() = %v, want %v", got, tt.wantStatus)
+			}
+
+			var recordedEvents []string
+			for len(recorder.Events) > 0 {
+				recordedEvents = append(recordedEvents, <-recorder.Events)
+			}
+			if !containsEvent(recordedEvents, tt.wantEvent) {
+				t.Errorf("events %q do not contain %q", recordedEvents, tt.wantEvent)
+			}
+			if containsEventWithReason(recordedEvents, tt.rejectEvent) {
+				t.Errorf("events %q unexpectedly contain reason %q", recordedEvents, tt.rejectEvent)
+			}
+		})
+	}
+}
+
+func containsEvent(recordedEvents []string, expected string) bool {
+	for _, event := range recordedEvents {
+		if event == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEventWithReason(recordedEvents []string, reason string) bool {
+	for _, event := range recordedEvents {
+		fields := strings.Fields(event)
+		if len(fields) > 1 && fields[1] == reason {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/helm/helm_test.go
+++ b/test/e2e/helm/helm_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -11,10 +11,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
 	. "github.com/onsi/gomega"
 	coh "github.com/oracle/coherence-operator/api/v1"
 	"github.com/oracle/coherence-operator/pkg/operator"
@@ -22,11 +24,62 @@ import (
 	"github.com/oracle/coherence-operator/test/e2e/helper/matchers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestEventsV1RBAC(t *testing.T) {
+	t.Run("cluster role", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		result, err := helmInstall()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		role := &rbacv1.ClusterRole{}
+		g.Expect(result.Get("coherence-operator", role)).To(Succeed())
+		assertEventsV1WriteRule(t, role.Rules)
+	})
+
+	t.Run("namespaced role", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		result, err := helmInstall("--set", "clusterRoles=false")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		role := &rbacv1.Role{}
+		g.Expect(result.Get("coherence-operator", role)).To(Succeed())
+		assertEventsV1WriteRule(t, role.Rules)
+	})
+}
+
+func TestGeneratedEventsV1RBAC(t *testing.T) {
+	g := NewGomegaWithT(t)
+	root, err := helper.FindProjectRootDir()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(root, "config", "rbac", "role.yaml"))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	role := &rbacv1.ClusterRole{}
+	g.Expect(yaml.Unmarshal(data, role)).To(Succeed())
+	assertEventsV1WriteRule(t, role.Rules)
+}
+
+func assertEventsV1WriteRule(t *testing.T, rules []rbacv1.PolicyRule) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	for _, rule := range rules {
+		if len(rule.APIGroups) == 1 && rule.APIGroups[0] == "events.k8s.io" &&
+			len(rule.Resources) == 1 && rule.Resources[0] == "events" {
+			g.Expect(rule.Verbs).To(ConsistOf("create", "patch"))
+			return
+		}
+	}
+
+	t.Fatalf("expected an events.k8s.io events rule with exactly create and patch verbs; rules=%v", rules)
+}
 
 func TestPodSecurityContext(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/test/e2e/remote/suspend_test.go
+++ b/test/e2e/remote/suspend_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.
  */
@@ -10,43 +10,93 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
 	. "github.com/onsi/gomega"
 	cohv1 "github.com/oracle/coherence-operator/api/v1"
 	"github.com/oracle/coherence-operator/pkg/utils"
 	"github.com/oracle/coherence-operator/test/e2e/helper"
-	"io"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
-	"time"
 )
 
 const testFinalizer = "coherence.oracle.com/test"
 
 func TestSuspendServices(t *testing.T) {
-	// Ensure that everything is cleaned up after the test!
-	testContext.CleanupAfterTest(t)
-	ctx := context.Background()
 	g := NewGomegaWithT(t)
 
 	ns := helper.GetTestNamespace()
 	c, err := helper.NewSingleCoherenceFromYamlWithSuffix(ns, "suspend-test.yaml", "-suspend")
 	g.Expect(err).NotTo(HaveOccurred())
+	runSuspendFinalizerTest(t, c, false, nil)
+}
 
-	installSimpleDeployment(t, c)
+func TestSuspendServicesWithIPv6PodIP(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ns := helper.GetTestNamespace()
+	c, err := helper.NewSingleCoherenceFromYamlWithSuffix(ns, "suspend-test.yaml", "-suspend-ipv6")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	c.Spec.Replicas = ptr.To(int32(1))
+	c.Spec.HeadlessServiceIpFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+	c.Spec.SuspendProbe = nil
+	if c.Spec.Coherence == nil {
+		c.Spec.Coherence = &cohv1.CoherenceSpec{}
+	}
+	if c.Spec.Coherence.WKA == nil {
+		c.Spec.Coherence.WKA = &cohv1.CoherenceWKASpec{}
+	}
+	c.Spec.Coherence.WKA.IPFamily = ptr.To(corev1.IPv6Protocol)
+
+	runSuspendFinalizerTest(t, c, true, validateIPv6PrimaryPod)
+}
+
+func runSuspendFinalizerTest(t *testing.T, c cohv1.Coherence, requirePersistencePVC bool, podValidator func(*testing.T, []corev1.Pod)) {
+	t.Helper()
+	// Ensure that everything is cleaned up after the test!
+	testContext.CleanupAfterTest(t)
+	ctx := context.Background()
+	g := NewGomegaWithT(t)
+
+	if requirePersistencePVC {
+		requireDefaultStorageClass(t)
+	}
+
+	err := testContext.Client.Create(ctx, &c)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	if requirePersistencePVC {
+		pvc, pvcErr := waitForPersistencePVC(&c)
+		g.Expect(pvcErr).NotTo(HaveOccurred())
+		t.Logf("PersistentVolumeClaim %s/%s is Bound", pvc.Namespace, pvc.Name)
+	}
+
+	assertDeploymentEventuallyInDesiredState(t, c, c.GetReplicas())
 
 	// get the StatefulSet for the deployment
-	sts, err := testContext.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, c.Name, metav1.GetOptions{})
+	sts, err := testContext.KubeClient.AppsV1().StatefulSets(c.Namespace).Get(ctx, c.Name, metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
+	pods, err := helper.ListCoherencePodsForDeployment(testContext, c.Namespace, c.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	if podValidator != nil {
+		podValidator(t, pods)
+	}
 
 	err = addTestFinalizer(&c)
 	g.Expect(err).NotTo(HaveOccurred())
+	defer removeAllFinalizersLoggingErrors(t, &c)
 
 	// Delete the deployment which should cause services to be suspended
 	// The deployment will not be deleted yet as we still have the test finalizer in place
@@ -61,12 +111,165 @@ func TestSuspendServices(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(svc["quorumStatus"]).To(ContainElement("Suspended"))
 
+	err = waitForServiceSuspendedEvent(c.UID, c.Namespace, sts.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+
 	// remove the test finalizer which should then let everything be deleted
 	err = removeAllFinalizers(&c)
 	g.Expect(err).NotTo(HaveOccurred())
 	// the StatefulSet should eventually be deleted
 	err = helper.WaitForDelete(testContext, sts)
 	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func validateIPv6PrimaryPod(t *testing.T, pods []corev1.Pod) {
+	t.Helper()
+	if len(pods) != 1 {
+		t.Fatalf("expected exactly one workload Pod, found %d: %v", len(pods), podAddressSummary(pods))
+	}
+
+	pod := pods[0]
+	addresses := podIPStrings(pod)
+	primary := net.ParseIP(pod.Status.PodIP)
+	if primary == nil || primary.To4() != nil {
+		t.Fatalf("expected Pod %s primary IP to be valid IPv6, primary=%q podIPs=%v", pod.Name, pod.Status.PodIP, addresses)
+	}
+
+	hasIPv4 := false
+	hasIPv6 := false
+	for _, podIP := range pod.Status.PodIPs {
+		parsed := net.ParseIP(podIP.IP)
+		if parsed == nil {
+			t.Fatalf("Pod %s has invalid address %q, primary=%q podIPs=%v", pod.Name, podIP.IP, pod.Status.PodIP, addresses)
+		}
+		if parsed.To4() == nil {
+			hasIPv6 = true
+		} else {
+			hasIPv4 = true
+		}
+	}
+	if !hasIPv4 || !hasIPv6 {
+		t.Fatalf("expected Pod %s to have IPv4 and IPv6 addresses, primary=%q podIPs=%v", pod.Name, pod.Status.PodIP, addresses)
+	}
+}
+
+func podAddressSummary(pods []corev1.Pod) []string {
+	summary := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		summary = append(summary, fmt.Sprintf("%s primary=%q podIPs=%v", pod.Name, pod.Status.PodIP, podIPStrings(pod)))
+	}
+	return summary
+}
+
+func podIPStrings(pod corev1.Pod) []string {
+	addresses := make([]string, 0, len(pod.Status.PodIPs))
+	for _, podIP := range pod.Status.PodIPs {
+		addresses = append(addresses, podIP.IP)
+	}
+	return addresses
+}
+
+func requireDefaultStorageClass(t *testing.T) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	classes, err := testContext.KubeClient.StorageV1().StorageClasses().List(testContext.Context, metav1.ListOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	var defaults []string
+	for _, class := range classes.Items {
+		annotations := class.GetAnnotations()
+		if strings.EqualFold(annotations["storageclass.kubernetes.io/is-default-class"], "true") ||
+			strings.EqualFold(annotations["storageclass.beta.kubernetes.io/is-default-class"], "true") {
+			defaults = append(defaults, class.Name)
+		}
+	}
+	g.Expect(defaults).NotTo(BeEmpty(), "expected a default StorageClass, found %s", mustJSON(classes.Items))
+}
+
+func waitForPersistencePVC(c *cohv1.Coherence) (*corev1.PersistentVolumeClaim, error) {
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		cohv1.LabelComponent, cohv1.LabelComponentPVC,
+		cohv1.LabelCoherenceDeployment, c.Name)
+	var claims []corev1.PersistentVolumeClaim
+
+	err := wait.PollUntilContextTimeout(testContext.Context, time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		list, err := testContext.KubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return false, err
+		}
+		claims = list.Items
+		if len(claims) > 1 {
+			return false, fmt.Errorf("expected one persistence PVC matching %q, found %s", selector, mustJSON(claims))
+		}
+		if len(claims) == 0 {
+			testContext.Logf("Waiting for persistence PVC matching %q", selector)
+			return false, nil
+		}
+		if claims[0].Status.Phase != corev1.ClaimBound {
+			testContext.Logf("Waiting for persistence PVC %s/%s to be Bound - phase %s",
+				claims[0].Namespace, claims[0].Name, claims[0].Status.Phase)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		classes, classesErr := testContext.KubeClient.StorageV1().StorageClasses().List(testContext.Context, metav1.ListOptions{})
+		events, eventsErr := testContext.KubeClient.CoreV1().Events(c.Namespace).List(testContext.Context, metav1.ListOptions{})
+		var classItems interface{} = "<unavailable>"
+		if classes != nil {
+			classItems = classes.Items
+		}
+		var eventItems interface{} = "<unavailable>"
+		if events != nil {
+			eventItems = events.Items
+		}
+		return nil, fmt.Errorf("waiting for persistence PVC matching %q: %w; PVCs=%s; StorageClasses=%s (error=%v); Events=%s (error=%v)",
+			selector, err, mustJSON(claims), mustJSON(classItems), classesErr, mustJSON(eventItems), eventsErr)
+	}
+	return claims[0].DeepCopy(), nil
+}
+
+func waitForServiceSuspendedEvent(uid types.UID, namespace, statefulSetName string) error {
+	var matchingEvents []string
+	err := wait.PollUntilContextTimeout(testContext.Context, time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		list, err := testContext.KubeClient.EventsV1().Events(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		matchingEvents = matchingEvents[:0]
+		foundSuccess := false
+		foundFailure := false
+		for _, event := range list.Items {
+			if event.Regarding.UID != uid {
+				continue
+			}
+			matchingEvents = append(matchingEvents, fmt.Sprintf("type=%s reason=%s note=%q", event.Type, event.Reason, event.Note))
+			if event.Reason == "ServiceSuspendFailed" {
+				foundFailure = true
+			}
+			if event.Type == corev1.EventTypeNormal && event.Reason == "ServiceSuspended" && strings.Contains(event.Note, statefulSetName) {
+				foundSuccess = true
+			}
+		}
+		if foundFailure {
+			return false, fmt.Errorf("found ServiceSuspendFailed event for Coherence UID %s: %v", uid, matchingEvents)
+		}
+		return foundSuccess, nil
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for normal ServiceSuspended event naming StatefulSet %s for Coherence UID %s: %w; matching events: %v",
+			statefulSetName, uid, err, matchingEvents)
+	}
+	return nil
+}
+
+func mustJSON(value interface{}) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("<json error: %v>", err)
+	}
+	return string(data)
 }
 
 func TestNotSuspendServicesWhenSuspendDisabled(t *testing.T) {

--- a/test/e2e/remote/suspend_test.go
+++ b/test/e2e/remote/suspend_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const testFinalizer = "coherence.oracle.com/test"
+const (
+	testFinalizer           = "coherence.oracle.com/test"
+	runIPv6FinalizerTestEnv = "RUN_IPV6_FINALIZER_TEST"
+)
 
 func TestSuspendServices(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -43,6 +47,10 @@ func TestSuspendServices(t *testing.T) {
 }
 
 func TestSuspendServicesWithIPv6PodIP(t *testing.T) {
+	if os.Getenv(runIPv6FinalizerTestEnv) != "true" {
+		t.Skipf("set %s=true to run the IPv6-primary dual-stack test", runIPv6FinalizerTestEnv)
+	}
+
 	g := NewGomegaWithT(t)
 
 	ns := helper.GetTestNamespace()


### PR DESCRIPTION
 ## Summary

  Fixes Bug 39737094, where Coherence resources could remain terminating because the service suspend probe constructed invalid URLs from IPv6 Pod addresses.

  For example:

  - Before: `http://fd02:0:0:6::8e35:6676/suspend`
  - After: `http://[fd02:0:0:6::8e35]:6676/suspend`

  ## Changes

  - Build HTTP probe endpoints with `net.JoinHostPort` so IPv6 addresses are correctly bracketed while preserving IPv4 and hostname behavior.
  - Correct the inverted service-suspension events:
    - Successful probes emit `ServiceSuspended`.
    - Failed probes emit `ServiceSuspendFailed`.
  - Ensure Events v1 records have valid non-empty actions and preserve formatted notes, including literal percent signs.
  - Grant the operator `create` and `patch` permissions for `events.events.k8s.io` in generated and Helm RBAC.
  - Add unit coverage for IPv4, IPv6, DNS, query paths, suspension results, and Events v1 recording.
  - Extend the dual-stack Kind workflow with an IPv6-primary Pod network and an end-to-end finalizer test that verifies:
    - The workload Pod has an IPv6 primary address.
    - The suspend probe succeeds during deletion.
    - A normal `ServiceSuspended` event is persisted.
    - The finalizer completes and the StatefulSet is removed.
  - Add dual-stack diagnostics, cleanup, and test artifact collection.

  ## Testing

  Validated with:

  - Focused tests for probe, event, StatefulSet, and reconciler packages.
  - Full Go operator unit-test package coverage across API, controller, package, and Helm test packages.
  - Focused `go vet` checks.
  - Helm RBAC rendering tests for both ClusterRole and namespaced Role modes.
  - Generated RBAC comparison.
  - Go formatting and `git diff --check`.
  - Workflow and shell syntax validation.

  The IPv6-primary integration scenario is scoped to the dual-stack GitHub Actions workflow through `RUN_IPV6_FINALIZER_TEST=true`.

  ## Upgrade note

  Standard manifest and Helm installations receive the Events v1 RBAC rule automatically. Installations using custom or externally managed RBAC must grant the operator `create` and `patch` permissions for `events` in the `events.k8s.io` API group.